### PR TITLE
[AGP-1602] Agentic Beta Setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "support@zapier.com"
   },
   "metadata": {
-    "description": "Official Zapier plugins — connect your AI to 8,000+ apps via the Model Context Protocol",
+    "description": "Official Zapier plugins — connect your AI to 9,000+ apps via the Model Context Protocol",
     "version": "1.0.0"
   },
   "plugins": [

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "support@zapier.com"
   },
   "metadata": {
-    "description": "Official Zapier plugins - connect your AI to 8,000+ apps via the Model Context Protocol",
+    "description": "Official Zapier plugins - connect your AI to 9,000+ apps via the Model Context Protocol",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "zapier",
       "source": "./plugins/zapier",
-      "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client."
+      "description": "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Connect your AI to thousands of apps with the Model Context Protocol**
 
-Transform your AI assistant from a conversational tool into a functional extension of your applications. [Zapier MCP](https://zapier.com/mcp) is a **remote** MCP server that gives your AI direct access to 8,000+ apps and 40,000+ actions—no complex API integrations required.
+Transform your AI assistant from a conversational tool into a functional extension of your applications. [Zapier MCP](https://zapier.com/mcp) is a **remote** MCP server that gives your AI direct access to 9,000+ apps and 40,000+ actions—no complex API integrations required.
 
 https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
 
@@ -54,7 +54,32 @@ Visit [mcp.zapier.com](https://mcp.zapier.com) to browse and enable specific act
 
 ## Built-in Tools
 
-Every Zapier MCP server comes with a set of meta-tools available immediately—before you configure any actions. These let your AI discover and understand what's possible:
+Zapier MCP servers operate in one of two modes. Your server's mode determines which built-in tools are available.
+
+### Agentic (Beta)
+
+The Agentic configuration is currently in Beta and being rolled out to all users. Agentic servers provide 14 static meta-tools for managing and executing actions entirely within the chat experience:
+
+| Tool | Category | Description |
+|------|----------|-------------|
+| `list_enabled_zapier_actions` | Action Management | See all your currently enabled actions |
+| `discover_zapier_actions` | Action Management | Search for apps and actions available to add |
+| `enable_zapier_action` | Action Management | Enable a specific action as a tool |
+| `disable_zapier_action` | Action Management | Disable an action you no longer need |
+| `auto_provision_mcp` | Action Management | Auto-setup tools from your existing Zapier connections |
+| `execute_zapier_read_action` | Execution | Run a read/search action (e.g., find an email, look up a contact) |
+| `execute_zapier_write_action` | Execution | Run a write action (e.g., send a message, create a task) |
+| `get_configuration_url` | Configuration | Get the URL to your Zapier MCP config page |
+| `list_zapier_skills` | Skills | List saved Zapier skills/workflows |
+| `get_zapier_skill` | Skills | Retrieve a specific skill |
+| `create_zapier_skill` | Skills | Create a new skill |
+| `update_zapier_skill` | Skills | Update an existing skill |
+| `delete_zapier_skill` | Skills | Delete a skill |
+| `send_feedback` | Feedback | Send feedback to Zapier |
+
+### Classic
+
+Classic servers expose one built-in tool alongside your configured action tools:
 
 | Tool | Description |
 |------|-------------|
@@ -63,6 +88,12 @@ Every Zapier MCP server comes with a set of meta-tools available immediately—b
 ---
 
 ## How Actions Work
+
+### Agentic (Beta)
+
+Actions are managed and executed directly in chat. Use `discover_zapier_actions` to find available apps, `enable_zapier_action` to add one, and `execute_zapier_read_action` / `execute_zapier_write_action` to run it. Your AI can also call `list_enabled_zapier_actions` at any time to see what's currently available.
+
+### Classic
 
 When you add an action at [mcp.zapier.com](https://mcp.zapier.com), it gets exposed as a dedicated tool on your MCP server. Your AI can then call it directly.
 
@@ -78,7 +109,7 @@ This repo also hosts official Zapier plugins for AI workflows. Each plugin is a 
 
 | Plugin | Category | Description |
 |--------|----------|-------------|
-| [Zapier](plugins/zapier/) | Productivity | Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client. Includes onboarding skills, status tools, and safety rules. |
+| [Zapier](plugins/zapier/) | Productivity | Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client. Includes onboarding skills, status tools, and safety rules. |
 
 ---
 

--- a/plugins/zapier/.claude-plugin/plugin.json
+++ b/plugins/zapier/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zapier",
   "version": "1.0.0",
-  "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
+  "description": "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
   "author": {
     "name": "Zapier",
     "email": "support@zapier.com"

--- a/plugins/zapier/.cursor-plugin/plugin.json
+++ b/plugins/zapier/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "zapier",
   "displayName": "Zapier",
   "version": "1.0.0",
-  "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
+  "description": "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
   "author": {
     "name": "Zapier",
     "email": "support@zapier.com"

--- a/plugins/zapier/README.md
+++ b/plugins/zapier/README.md
@@ -1,6 +1,6 @@
 # Zapier Plugin
 
-Connect 8,000+ apps to your AI workflow. Configure your actions at mcp.zapier.com, and each one becomes a tool your AI can call directly — no config files, no tokens, no setup scripts.
+Connect 9,000+ apps to your AI workflow. Configure your actions at mcp.zapier.com, and each one becomes a tool your AI can call directly — no config files, no tokens, no setup scripts.
 
 ## Quick Start
 
@@ -11,9 +11,9 @@ After installing:
    - **Claude Desktop:** Customize > Connectors > Zapier > click **Connect**
    - **Other clients:** Find the Zapier MCP server in your MCP settings and connect
 2. Sign in to your Zapier account when prompted
-3. Open a chat and say **"setup zapier"** to add tools to your workflow
+3. Open a chat and say **"setup zapier"** to get started
 
-The onboarding skill will help you pick the right tools and generate a personalized AI profile so future chats know your tools.
+Your server will be in one of two modes — the plugin detects which one automatically and guides you through the right flow.
 
 ## What's Included
 
@@ -26,7 +26,17 @@ The onboarding skill will help you pick the right tools and generate a personali
 
 ## How Tools Work
 
-The plugin connects to Zapier's MCP server. Each action you configure at [mcp.zapier.com](https://mcp.zapier.com) becomes its own MCP tool, named with the pattern `app_action_name`:
+Zapier MCP operates in one of two modes depending on your server configuration. The plugin detects the mode automatically.
+
+### Agentic (Beta)
+
+The Agentic configuration is currently in Beta and being rolled out to all users. In this mode, your server provides 14 static meta-tools for managing and executing actions directly in chat. You can discover apps, enable/disable actions, and execute reads and writes without leaving the conversation. Onboarding is handled by a Zapier-hosted skill — just say "setup zapier" and the plugin will walk you through it.
+
+Key tools: `list_enabled_zapier_actions`, `discover_zapier_actions`, `enable_zapier_action`, `execute_zapier_read_action`, `execute_zapier_write_action`, `list_zapier_skills`, `get_zapier_skill`, and more.
+
+### Classic
+
+In Classic mode, each action you configure at [mcp.zapier.com](https://mcp.zapier.com) becomes its own MCP tool, named with the pattern `app_action_name`:
 
 - **`gmail_send_email`** — Send an email via Gmail
 - **`slack_find_message`** — Search for a Slack message

--- a/plugins/zapier/rules/zapier-lifecycle.mdc
+++ b/plugins/zapier/rules/zapier-lifecycle.mdc
@@ -19,9 +19,13 @@ Identify the mode once at the start of a conversation and follow the correspondi
 
 ## First-time setup
 
-If no Zapier MCP tools are available at all, the Zapier MCP server is installed but not yet authenticated - please prompt for authentication.
+If no Zapier MCP tools are available at all, the Zapier MCP server is installed but not yet authenticated.
 
-**In Cursor:** Prompt the user to authenticate the MCP server
+First, attempt to authenticate directly in the chat by calling `mcp_auth` on the Zapier MCP server. If that succeeds, proceed to mode detection and onboarding.
+
+If `mcp_auth` fails or is unavailable, fall back to manual instructions based on their client:
+
+**In Cursor:** Tell the user to go to **Settings > Cursor Settings > Tools & MCP** and click **Connect** next to the Zapier MCP server. They can also press **Cmd+Shift+P** and search for 'MCP'.
 
 **In Claude Desktop:** Tell the user to go to **Customize > Connectors > Zapier** and click **Connect**.
 
@@ -161,6 +165,8 @@ Users may have both Zapier MCP actions AND native MCP servers for the same app (
 When an error occurs, explain it in plain language. Don't dump raw error messages. "Your Slack connection needs to be re-authenticated" beats "Error 401: OAuth token invalid for SlackCLIAPI."
 
 ## Setup, maintenance, and troubleshooting
+
+- **Intro / discovery questions** ("how does Zapier work", "show me the Zapier plugin", "what is Zapier MCP", "tell me about Zapier"): Trigger the **zapier-setup** skill. It handles the intro pitch, authentication, mode detection, and full setup flow for both new and returning users.
 
 ### Agentic mode
 

--- a/plugins/zapier/rules/zapier-lifecycle.mdc
+++ b/plugins/zapier/rules/zapier-lifecycle.mdc
@@ -7,21 +7,79 @@ alwaysApply: true
 
 This workspace uses Zapier MCP to connect your AI to external apps. These rules govern how you interact with Zapier tools.
 
+## Detecting your mode
+
+Zapier MCP operates in one of two modes depending on how the user's server is configured. Check which tools are available to determine the mode:
+
+- **Agentic mode**: `list_enabled_zapier_actions`, `discover_zapier_actions`, `execute_zapier_read_action`, `execute_zapier_write_action`, and the other static meta-tools are present. The reliable signal is the presence of `list_enabled_zapier_actions`.
+- **Classic mode**: `get_configuration_url` is present alongside individual action tools named `app_action_name` (e.g., `gmail_send_email`, `slack_find_message`). There is no `list_enabled_zapier_actions` tool.
+- **Not connected**: No Zapier tools are available at all. The server needs authentication (see "First-time setup").
+
+Identify the mode once at the start of a conversation and follow the corresponding guidance below.
+
 ## First-time setup
 
-If no Zapier MCP tools are available at all (not even `get_configuration_url`), the Zapier MCP server is installed but not yet authenticated.
+If no Zapier MCP tools are available at all, the Zapier MCP server is installed but not yet authenticated - please prompt for authentication.
 
-**In Cursor:** Tell the user to go to **Settings > Cursor Settings > Tools & MCP** and click **Connect** next to the Zapier MCP server (shortcut: **Cmd+Shift+P** > search "MCP"). This will open the Zapier sign-in flow.
+**In Cursor:** Prompt the user to authenticate the MCP server
 
 **In Claude Desktop:** Tell the user to go to **Customize > Connectors > Zapier** and click **Connect**.
 
 **In other clients:** Tell the user to authenticate the Zapier MCP server through their client's MCP server settings. This will redirect them to mcp.zapier.com to sign in.
 
-Once authenticated, **immediately trigger the zapier-setup skill**. Do not tell the user to "start using tools" or suggest other skills — a freshly authenticated server has no action tools configured yet, so `/zapier-setup` is the only useful next step.
+Once authenticated, determine the mode and follow the appropriate onboarding path:
 
-Do not suggest `/create-my-tools-profile` or `/zapier-status` until action tools exist. Do not try to call any Zapier tools or suggest the user configure actions until the server is connected.
+- **Agentic mode**: Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` and follow its instructions. If authentication is needed, help the user through it, then retry.
+- **Classic mode**: Immediately trigger the **zapier-setup** skill. Do not tell the user to "start using tools" or suggest other skills — a freshly authenticated Classic server has no action tools configured yet, so `/zapier-setup` is the only useful next step.
+
+Do not suggest `/create-my-tools-profile` or `/zapier-status` until action tools exist (Classic) or enabled actions exist (Agentic). Do not try to call any Zapier tools or suggest the user configure actions until the server is connected.
 
 ## How tools work
+
+### Agentic mode
+
+Zapier MCP provides 14 static meta-tools. These tools never change — they are the interface for managing and executing actions dynamically within the chat.
+
+**Action management:**
+
+| Tool                          | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| `list_enabled_zapier_actions` | See all currently enabled actions                        |
+| `discover_zapier_actions`     | Search for apps and actions available to add              |
+| `enable_zapier_action`        | Enable a specific action as a tool                       |
+| `disable_zapier_action`       | Disable an action you no longer need                     |
+| `auto_provision_mcp`          | Auto-setup tools from the user's existing Zapier connections |
+
+**Execution:**
+
+| Tool                           | Purpose                                              |
+| ------------------------------ | ---------------------------------------------------- |
+| `execute_zapier_read_action`   | Run a read/search action (e.g., find an email)       |
+| `execute_zapier_write_action`  | Run a write action (e.g., send a message)            |
+
+**Configuration:**
+
+| Tool                    | Purpose                                    |
+| ----------------------- | ------------------------------------------ |
+| `get_configuration_url` | Get the URL to the Zapier MCP config page  |
+
+**Skills:**
+
+| Tool                   | Purpose                      |
+| ---------------------- | ---------------------------- |
+| `list_zapier_skills`   | List saved skills/workflows  |
+| `get_zapier_skill`     | Retrieve a specific skill    |
+| `create_zapier_skill`  | Create a new skill           |
+| `update_zapier_skill`  | Update an existing skill     |
+| `delete_zapier_skill`  | Delete a skill               |
+
+**Feedback:**
+
+| Tool            | Purpose               |
+| --------------- | --------------------- |
+| `send_feedback` | Send feedback to Zapier |
+
+### Classic mode
 
 Zapier MCP exposes each configured action as its own tool. Tool names follow the pattern `app_action_name` (e.g., `gmail_send_email`, `slack_find_message`, `jira_find_issue_by_key`). The tool description identifies the associated app.
 
@@ -35,6 +93,17 @@ All other tools are action-specific — call them directly to execute the action
 
 ## Using tools
 
+### Agentic mode
+
+1. **Call `list_enabled_zapier_actions` first** to see what actions are available before trying to execute anything.
+2. **Use `execute_zapier_read_action`** for reads/searches and **`execute_zapier_write_action`** for writes. Do not try to call action tools by name — they don't exist as individual tools in this mode.
+3. **To add actions**, use `discover_zapier_actions` to find what's available, then `enable_zapier_action` to add it. Actions are managed in-chat, not through a web UI.
+4. **To remove actions**, use `disable_zapier_action`.
+5. **Auth may be needed.** If an execute call returns an auth error, the user needs to authenticate that app at mcp.zapier.com.
+6. **Skills** can contain saved workflows and instructions. Use `list_zapier_skills` to discover them and `get_zapier_skill` to retrieve one.
+
+### Classic mode
+
 1. **Call action tools directly.** Each tool IS the action. No intermediate steps needed — just call `slack_send_channel_message` to send a Slack message.
 2. **Auth may be needed.** If a tool call returns an auth error, the user needs to authenticate that app at mcp.zapier.com.
 3. **To add or remove actions**, call `get_configuration_url` and direct the user there. Actions are managed through the web UI, not through MCP tools.
@@ -42,6 +111,13 @@ All other tools are action-specific — call them directly to execute the action
 ## Safety model
 
 **Reads are free. Writes need confirmation.**
+
+### Agentic mode
+
+- **`execute_zapier_read_action`**: Just do it. No need to ask permission to look something up. If the user mentions a Slack message, Jira ticket, calendar event, or anything in a connected app, search for it.
+- **`execute_zapier_write_action`**: Always confirm before executing. Show the user exactly what you're about to do (message text, issue fields, record data) and wait for approval. The exception: if the user explicitly said "send it" or "do it" in the same message.
+
+### Classic mode
 
 Determine read vs write from the tool name and description:
 
@@ -59,6 +135,20 @@ Users may have both Zapier MCP actions AND native MCP servers for the same app (
 
 ## Error handling
 
+### Agentic mode
+
+| Error pattern                               | What it means                   | What to do                                                                                           |
+| ------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 401 / "unauthorized"                        | Auth expired or missing         | Tell the user to re-authenticate at mcp.zapier.com                                                   |
+| "authentication required" on a specific app | App connection needs OAuth      | Direct user to mcp.zapier.com to connect that specific app                                           |
+| Action not found / not enabled              | Action not enabled              | Use `discover_zapier_actions` to find it, then `enable_zapier_action` to add it                      |
+| Meta-tool not found (e.g., `list_enabled_zapier_actions` missing) | Server auth issue | The server needs to be reconnected — follow "First-time setup"                          |
+| Timeout / no response                       | Server issue                    | Wait a moment and retry once. If it fails again, mention it.                                         |
+| "rate limit"                                | Too many calls                  | Slow down. Space out tool calls.                                                                     |
+| Empty results                               | No matching data (not an error) | Tell the user nothing was found. Don't retry with broader terms unless asked.                        |
+
+### Classic mode
+
 | Error pattern                               | What it means                   | What to do                                                                    |
 | ------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------- |
 | 401 / "unauthorized"                        | Auth expired or missing         | Tell the user to re-authenticate at mcp.zapier.com                            |
@@ -71,6 +161,14 @@ Users may have both Zapier MCP actions AND native MCP servers for the same app (
 When an error occurs, explain it in plain language. Don't dump raw error messages. "Your Slack connection needs to be re-authenticated" beats "Error 401: OAuth token invalid for SlackCLIAPI."
 
 ## Setup, maintenance, and troubleshooting
+
+### Agentic mode
+
+- **New users / onboarding**: Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` and follow its instructions. If authentication is needed, help the user through it, then retry. This is the primary onboarding path.
+- **To discover available skills**, call `list_zapier_skills`. Skills can contain saved workflows, instructions, and automation recipes managed by the user and Zapier.
+- For health checks, audits, or troubleshooting, trigger the **zapier-status** skill.
+
+### Classic mode
 
 - **New users / fresh installs**: Push the **zapier-setup** skill first. This is the primary onboarding path — get tools configured before anything else.
 - If tools aren't working or the user wants to add apps, trigger the **zapier-setup** skill.

--- a/plugins/zapier/skills/create-my-tools-profile/SKILL.md
+++ b/plugins/zapier/skills/create-my-tools-profile/SKILL.md
@@ -11,15 +11,30 @@ This is the "post-onboarding" step: the user has already added tools via the set
 
 ## Prerequisite: Verify tools exist
 
-Before proceeding, check that Zapier MCP action tools are available (tools like `slack_send_channel_message`, `gmail_find_email` — not just the built-in `get_configuration_url`).
+First, determine the mode by checking if `list_enabled_zapier_actions` is available as a tool.
 
-If no action tools are configured, **stop here** and redirect:
+**Agentic mode:** Call `list_enabled_zapier_actions`. If it returns an empty list, **stop here** and redirect — call `get_zapier_skill` with name `"zapier-mcp-onboarding"` to get tools configured first. Do not continue with the steps below.
+
+**Classic mode:** Check that action tools are available (tools like `slack_send_channel_message`, `gmail_find_email` — not just the built-in `get_configuration_url`). If no action tools are configured, **stop here** and trigger the **zapier-setup** skill instead. Do not continue with the steps below.
+
+If no tools exist at all:
 
 "You don't have any tools set up yet, so there's nothing to build a profile from. Let's get some tools configured first."
 
-Then trigger the **zapier-setup** skill instead. Do not continue with the steps below.
-
 ## Step 1: Inventory enabled tools
+
+### Agentic mode
+
+Call `list_enabled_zapier_actions` to get the full list of enabled actions. Parse the returned actions into a structured list:
+
+- **App name**: from the action's app field or description
+- **Action name**: the human-readable action name from the response
+- **Action identifier**: the ID or reference used when calling `execute_zapier_read_action` / `execute_zapier_write_action`
+- **Read vs write**: infer from the action name — find/search/get/list/lookup = read, send/create/update/add/delete = write
+
+Exclude the 14 static meta-tools from the profile — only include the user's enabled actions.
+
+### Classic mode
 
 Inspect the available Zapier MCP tools. Each configured action is its own tool with a name following the pattern `app_action_name` (e.g., `slack_send_channel_message`, `gmail_find_email`). The built-in `get_configuration_url` tool should be excluded from the profile.
 
@@ -88,6 +103,10 @@ alwaysApply: true
 
 ### Profile content (shared across all clients)
 
+**Agentic mode** — actions are executed via `execute_zapier_read_action` and `execute_zapier_write_action`, not as individual tool calls. The profile should reference action identifiers used with those execute tools.
+
+**Classic mode** — actions are individual tools called directly by name (e.g., `slack_send_channel_message`).
+
 ```markdown
 # My Zapier tools
 
@@ -97,8 +116,8 @@ You have access to the following apps and actions through Zapier MCP. Use them p
 
 ### [App Name]
 
-- **[Action Name]** (`tool_name`) — [one-line description of when to use it]
-- **[Action Name]** (`tool_name`) — [one-line description of when to use it]
+- **[Action Name]** (`tool_name_or_action_id`) — [one-line description of when to use it]
+- **[Action Name]** (`tool_name_or_action_id`) — [one-line description of when to use it]
 
 ### [App Name]
 
@@ -157,7 +176,7 @@ To update this profile after adding new tools, just say 'update my tools profile
 If the user says "update my tools profile" and the file already exists:
 
 1. Read the existing file
-2. Inspect the currently available Zapier MCP tools for the current state
+2. Get the current tool inventory (Agentic: call `list_enabled_zapier_actions`; Classic: inspect available MCP tools)
 3. Diff what's new vs. what's already documented
 4. Update the file, preserving any custom edits the user made to the preferences section
 5. Note what changed: "Added 3 new Google Sheets actions. Your custom preferences were preserved."

--- a/plugins/zapier/skills/zapier-setup/SKILL.md
+++ b/plugins/zapier/skills/zapier-setup/SKILL.md
@@ -1,23 +1,49 @@
 ---
 name: zapier-setup
-description: Set up Zapier MCP and add tools to your AI assistant. Runs a diagnostic, then branches into the right flow: summary for healthy setups, reconnect for broken auth, onboarding for fresh installs, or config help when the server is missing. Use when getting started, troubleshooting connection issues, adding new tools, or when the user asks "what can I do now" or "what can I do with Zapier".
+description: Set up Zapier MCP and add tools to your AI assistant. Introduces what Zapier can do, walks through authentication, detects your server mode, then branches into the right flow — summary for healthy setups, reconnect for broken auth, onboarding for fresh installs, or config help when the server is missing. Use when getting started, troubleshooting connection issues, adding new tools, or when the user asks "what can I do now", "what can I do with Zapier", "show me how the Zapier plugin works", "what is Zapier MCP", "how does Zapier work", or "tell me about Zapier".
 ---
 
 # Zapier setup
 
-Check whether any Zapier MCP tools are available, then branch based on what comes back.
+Introduce Zapier MCP, get the user authenticated, detect their server mode, then guide them through the appropriate setup flow.
 
-## Pre-check: Agentic mode
+## Step 1: Introduction
 
-Before running the Classic diagnostic below, check if `list_enabled_zapier_actions` is available as a tool. If it is, the user is on Agentic mode and this skill's Classic flow does not apply.
+Start by describing what Zapier MCP can do for the user, then get them authenticated.
 
-**If on Agentic mode:** Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` on the Zapier MCP server and follow its instructions. If authentication is needed, help the user through it, then retry the call. **Do not continue with the steps below** — the Zapier-hosted onboarding skill handles the entire Agentic setup flow.
+### Pitch
 
----
+"Zapier MCP connects your AI assistant to 9,000+ apps — Slack, Gmail, Google Calendar, Jira, Notion, HubSpot, and thousands more. Once set up, you can search across your tools, take actions, and automate workflows, all through natural conversation. It's personalized to your workflow — you pick the apps and actions that matter to you, and your AI learns to use them."
 
-The rest of this skill applies only to **Classic mode** (where `get_configuration_url` and individual `app_action_name` tools are present, but `list_enabled_zapier_actions` is not).
+### Check connection
 
-## Step 1: Diagnose
+Check if any Zapier MCP tools are available:
+
+- **Tools are available** (either Agentic meta-tools or Classic action tools): The user is already authenticated. Give a shorter version of the pitch — "You've got Zapier MCP installed and connected. Let me check what you have set up." — then proceed to Step 2.
+
+- **No Zapier tools available at all**: The server is installed but needs authentication. First, attempt to authenticate directly in the chat by calling `mcp_auth` on the Zapier MCP server. If that succeeds, re-check available tools and proceed to Step 2.
+
+  If `mcp_auth` fails or is unavailable, fall back to manual instructions based on their client:
+
+  - **In Cursor:** "Let's get you connected. Go to **Settings > Cursor Settings > Tools & MCP** and click **Connect** next to the Zapier MCP server. You can also press **Cmd+Shift+P** and search for 'MCP' to get there quickly."
+  - **In Claude Desktop:** "Let's get you connected. Go to **Customize > Connectors > Zapier** and click **Connect**."
+  - **In other clients:** "Let's get you connected. Find the Zapier MCP server in your client's MCP settings and click Connect. This will redirect you to mcp.zapier.com to sign in."
+
+  Detect which client is in use from the environment or conversation context. If unclear, give the generic instructions.
+
+  Wait for the user to confirm ("done"), then re-check available tools and proceed to Step 2.
+
+## Step 2: Detect mode
+
+Check which tools are available to determine the server mode:
+
+- **Agentic mode**: `list_enabled_zapier_actions` is available as a tool. Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` on the Zapier MCP server and follow its instructions. If authentication is needed, help the user through it, then retry the call. **Do not continue with the steps below** — the Zapier-hosted onboarding skill handles the entire Agentic setup flow.
+
+- **Classic mode**: `get_configuration_url` and/or individual `app_action_name` tools are present, but `list_enabled_zapier_actions` is not. Continue to Step 3.
+
+## Step 3: Diagnose
+
+This step applies only to **Classic mode**.
 
 Try calling `get_configuration_url` or any Zapier tool. The result determines which branch to follow:
 
@@ -72,15 +98,15 @@ The Zapier MCP server is installed via the plugin but hasn't been authenticated 
 
 1. Tell the user the Zapier plugin is installed but needs to be connected first.
 
-2. Guide them based on their client:
+2. Attempt to authenticate directly in the chat by calling `mcp_auth` on the Zapier MCP server. If that succeeds, skip to step 5.
+
+3. If `mcp_auth` fails or is unavailable, fall back to manual instructions based on their client:
 
    - **In Cursor:** "Go to **Settings > Cursor Settings > Tools & MCP** and click **Connect** next to the Zapier MCP server. You can also press **Cmd+Shift+P** and search for 'MCP' to get there quickly."
    - **In Claude Desktop:** "Go to **Customize > Connectors > Zapier** and click **Connect**."
    - **In other clients:** "Find the Zapier MCP server in your client's MCP settings and connect it. This will redirect you to mcp.zapier.com to sign in."
 
    Detect which client is in use from the environment or conversation context. If unclear, give the generic instructions.
-
-3. Explain that connecting will open the Zapier sign-in flow at mcp.zapier.com where they'll authenticate their account.
 
 4. Wait for the user to confirm ("done").
 

--- a/plugins/zapier/skills/zapier-setup/SKILL.md
+++ b/plugins/zapier/skills/zapier-setup/SKILL.md
@@ -7,6 +7,16 @@ description: Set up Zapier MCP and add tools to your AI assistant. Runs a diagno
 
 Check whether any Zapier MCP tools are available, then branch based on what comes back.
 
+## Pre-check: Agentic mode
+
+Before running the Classic diagnostic below, check if `list_enabled_zapier_actions` is available as a tool. If it is, the user is on Agentic mode and this skill's Classic flow does not apply.
+
+**If on Agentic mode:** Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` on the Zapier MCP server and follow its instructions. If authentication is needed, help the user through it, then retry the call. **Do not continue with the steps below** — the Zapier-hosted onboarding skill handles the entire Agentic setup flow.
+
+---
+
+The rest of this skill applies only to **Classic mode** (where `get_configuration_url` and individual `app_action_name` tools are present, but `list_enabled_zapier_actions` is not).
+
 ## Step 1: Diagnose
 
 Try calling `get_configuration_url` or any Zapier tool. The result determines which branch to follow:

--- a/plugins/zapier/skills/zapier-status/SKILL.md
+++ b/plugins/zapier/skills/zapier-status/SKILL.md
@@ -7,7 +7,7 @@ description: Check the health of your Zapier MCP setup. Three modes — health c
 
 Three modes for monitoring and maintaining a Zapier MCP setup. Determine the mode from context, or ask if unclear.
 
-Each configured action is its own MCP tool (e.g., `slack_send_channel_message`, `gmail_find_email`). The tool description identifies the associated app. Inspect the available Zapier MCP tools to understand what's configured.
+**First, detect the server mode:** If `list_enabled_zapier_actions` is available, the user is on **Agentic mode**. Otherwise, the user is on **Classic mode** where each configured action is its own MCP tool (e.g., `slack_send_channel_message`, `gmail_find_email`).
 
 ## Mode 1: Health check
 
@@ -17,11 +17,13 @@ A quick dashboard view of the current state.
 
 ### Steps
 
-1. Check the available Zapier MCP tools. Each action tool follows the pattern `app_action_name`. The built-in `get_configuration_url` tool is always present when the server is connected.
+1. Check the available tools:
+   - **Agentic mode:** Call `list_enabled_zapier_actions` to get the inventory of enabled actions.
+   - **Classic mode:** Inspect the available Zapier MCP tools. Each action tool follows the pattern `app_action_name`. The built-in `get_configuration_url` tool is always present when the server is connected.
 
-2. If no Zapier tools are available: report the connection status and suggest running **zapier-setup**.
+2. If no Zapier tools are available: report the connection status and suggest running **zapier-setup** (Classic) or calling `get_zapier_skill` with name `"zapier-mcp-onboarding"` (Agentic).
 
-3. If tools are available, build a summary by grouping action tools by app (identified from each tool's description):
+3. If tools/actions are available, build a summary by grouping actions by app (Agentic: from the `list_enabled_zapier_actions` response; Classic: from each tool's description):
 
 **For each app**, show:
 
@@ -57,7 +59,9 @@ Find inefficiencies: duplicate actions, unused tools, conflicts with native MCP 
 
 ### Steps
 
-1. Inspect the available Zapier MCP action tools to get the full inventory.
+1. Get the full inventory:
+   - **Agentic mode:** Call `list_enabled_zapier_actions`.
+   - **Classic mode:** Inspect the available Zapier MCP action tools.
 
 2. **Check for duplicates within Zapier MCP:**
    - Multiple actions for the same app that do similar things (e.g., both `slack_find_message` and `slack_search_messages`)
@@ -91,7 +95,9 @@ Recommended removals: 4 actions
 Want me to show you how to clean these up?
 ```
 
-6. If the user says yes, call `get_configuration_url` and direct them to the web UI to remove the recommended actions. List exactly which ones to remove.
+6. If the user says yes:
+   - **Agentic mode:** Use `disable_zapier_action` to remove the recommended actions directly in chat.
+   - **Classic mode:** Call `get_configuration_url` and direct them to the web UI to remove the recommended actions. List exactly which ones to remove.
 
 ## Mode 3: Diagnose
 
@@ -107,9 +113,11 @@ Systematic troubleshooting with error pattern matching.
 
    a. **Connection check:** Try calling `get_configuration_url` or any available Zapier tool. If nothing works, the problem is server-level (auth, config, network).
 
-   b. **Action check:** Is the specific action tool available? If not, the user needs to add it through the web UI.
+   b. **Action check:**
+      - **Agentic mode:** Call `list_enabled_zapier_actions` to see if the action is enabled. If not, use `discover_zapier_actions` to find it and `enable_zapier_action` to add it.
+      - **Classic mode:** Is the specific action tool available? If not, the user needs to add it through the web UI.
 
-   c. **Auth check:** Try calling a read action tool for the affected app. If it returns an auth error, the app connection needs re-authentication.
+   c. **Auth check:** Try calling a read action for the affected app (Agentic: `execute_zapier_read_action`; Classic: the specific read tool). If it returns an auth error, the app connection needs re-authentication.
 
    d. **Parameter check:** Review the failing call's parameters. Common issues:
    - Missing required fields
@@ -122,7 +130,7 @@ Systematic troubleshooting with error pattern matching.
 | ------------------------------------------ | ----------------------------------- | ------------------------------------------------------------- |
 | All tools fail                             | Server auth expired                 | Re-authenticate at mcp.zapier.com                             |
 | One app fails, others work                 | App-level auth expired              | Re-connect that specific app                                  |
-| Tool not found / unavailable               | Action not configured               | Direct user to `get_configuration_url` to add it              |
+| Tool not found / unavailable               | Action not configured               | Agentic: `discover_zapier_actions` + `enable_zapier_action`. Classic: direct user to `get_configuration_url` to add it |
 | "invalid params"                           | Wrong fields or format              | Check the tool's parameter schema                             |
 | Results are empty but expected data exists | Search too narrow or wrong field    | Broaden the search or check field names                       |
 | Timeout on execute                         | Server overloaded or action is slow | Retry once, then report if persistent                         |
@@ -142,6 +150,6 @@ Systematic troubleshooting with error pattern matching.
 
 ## General notes
 
-- Always check available Zapier MCP tools as the first diagnostic step in any mode.
+- Always check available Zapier MCP tools as the first diagnostic step in any mode. On Agentic, this means calling `list_enabled_zapier_actions`. On Classic, this means inspecting the available tool names.
 - Don't dump raw error messages. Translate them into plain language.
 - If a problem is beyond what the skill can diagnose (server-side bug, API outage), say so and suggest checking [status.zapier.com](https://status.zapier.com) or contacting support.


### PR DESCRIPTION
### Context

The Cursor plugin bundles its own skills, and there is a potential collision with the onboarding skill loaded from the MCP server. We need to ensure that plugin-bundled skills don't conflict with the onboarding skill and that they conditionally work well together.

### What Was Built

- Ensured onboarding skill from MCP server takes priority or coexists gracefully with plugin-bundled skills
- Defined conditional behavior: if user is in onboarding flow, plugin skills should not interfere

### Acceptance criteria

- Cursor users can complete onboarding without plugin skill interference
- Plugin skills still work normally outside of onboarding context
- Tested in Cursor with both plugin installed and MCP server connected