### PR TITLE
Add Kiro Powers Setup Instructions

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -1,0 +1,44 @@
+---
+name: "zapier"
+displayName: "Zapier"
+description: "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your AI assistant."
+keywords: ["zapier", "automation", "integrations", "workflow", "ai-actions", "mcp", "no-code", "productivity", "slack", "gmail", "jira", "notion", "hubspot"]
+---
+
+# Zapier Power
+
+Connect your AI assistant to 9,000+ apps — Slack, Gmail, Google Calendar, Jira, Notion, HubSpot, and thousands more. Once set up, you can search across your tools, take actions, and automate workflows through natural conversation.
+
+## Onboarding
+
+### Step 1: Connect the Zapier MCP server
+
+After installing this power, connect the Zapier MCP server:
+
+Connection: HTTPS API endpoint at https://mcp.zapier.com/api/v1/connect
+Authorization: Use OAuth to connect to the Zapier MCP server
+
+### Step 2: Detect your server mode
+
+Zapier MCP operates in one of two modes. Check which tools are available:
+
+- **Agentic mode**: `list_enabled_zapier_actions` is present — actions are managed and executed via meta-tools in chat
+- **Classic mode**: `get_configuration_url` + individual `app_action_name` tools (e.g., `gmail_send_email`) — each configured action is its own MCP tool
+- **Not connected**: No Zapier tools available — the server needs authentication
+
+### Step 3: Get started
+
+- **Agentic mode**: Call `get_zapier_skill` with name `"zapier-mcp-onboarding"` and follow its instructions
+- **Classic mode**: Say **"setup zapier"** to trigger the setup workflow
+- **Not connected**: Attempt `mcp_auth` on the Zapier MCP server, or follow the manual connection steps above
+
+## When to Load Steering Files
+
+- Setting up Zapier or troubleshooting connection issues → `zapier-setup.md`
+- Checking tool health, auditing setup, or diagnosing broken tools → `zapier-status.md`
+- Generating a personalized tools profile after setup → `create-my-tools-profile.md`
+- Any interaction with Zapier MCP tools (reads, writes, error handling) → `zapier-lifecycle.md`
+
+## MCP Server
+
+This power uses the Zapier MCP server defined in `mcp.json`. The server connects to `https://mcp.zapier.com/api/v1/connect` and requires authentication via mcp.zapier.com.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,1 @@
+/Users/brody/git/zapier/zapier-mcp/plugins/zapier/.mcp.json

--- a/steering/create-my-tools-profile.md
+++ b/steering/create-my-tools-profile.md
@@ -1,0 +1,1 @@
+../plugins/zapier/skills/create-my-tools-profile/SKILL.md

--- a/steering/zapier-setup.md
+++ b/steering/zapier-setup.md
@@ -1,0 +1,1 @@
+../plugins/zapier/skills/zapier-setup/SKILL.md

--- a/steering/zapier-status.md
+++ b/steering/zapier-status.md
@@ -1,0 +1,1 @@
+../plugins/zapier/skills/zapier-status/SKILL.md


### PR DESCRIPTION
This pull request introduces initial documentation and configuration files for integrating Zapier as a "Power" via the Zapier MCP server. The main focus is on onboarding instructions, server connection details, and references to supporting steering and skill files.

Key additions and changes:

**Zapier Power Documentation:**

* Added a comprehensive `POWER.md` file describing how to connect and use Zapier with the AI assistant, including onboarding steps, server modes, and references to steering files for setup, troubleshooting, and tool management.

**Configuration and Steering Files:**

* Added a reference to the Zapier MCP server configuration in `mcp.json`, specifying the connection path for the plugin.
* Linked steering files to their respective skill documentation so they are in the right place for being auto-added via their GitHub linking for a listing in their Marketplace:
  - `steering/create-my-tools-profile.md` now points to the Create My Tools Profile skill.
  - `steering/zapier-setup.md` now points to the Zapier Setup skill.
  - `steering/zapier-status.md` now points to the Zapier Status skill.