### PR TITLE
Fix root MCP config symlink

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,1 +1,1 @@
-/Users/brody/git/zapier/zapier-mcp/plugins/zapier/.mcp.json
+plugins/zapier/.mcp.json


### PR DESCRIPTION
Summary:
- Fixes the root `mcp.json` symlink so fresh clones resolve to the checked-in Zapier MCP config.
- Keeps the config source at `plugins/zapier/.mcp.json`.

Testing:
- `readlink mcp.json`
- `test -e mcp.json && test -f mcp.json && jq empty mcp.json`
- `cmp -s mcp.json plugins/zapier/.mcp.json`
- `git diff --check`
- `jq empty .github/plugin/marketplace.json .cursor-plugin/marketplace.json .claude-plugin/marketplace.json plugins/zapier/.mcp.json plugins/zapier/.cursor-plugin/plugin.json plugins/zapier/.claude-plugin/plugin.json plugins/zapier/.github/plugin/plugin.json mcp.json`