### PR TITLE
fix: add required "type": "http" to plugins/zapier/.mcp.json

### DIFF
--- a/plugins/zapier/.mcp.json
+++ b/plugins/zapier/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "zapier": {
+      "type": "http",
       "url": "https://mcp.zapier.com/api/v1/connect"
     }
   }


### PR DESCRIPTION
## Problem
Claude Code rejects this plugin's `.mcp.json` at load time:

```
[ERROR] Invalid MCP server config for zapier in .../plugins/zapier/.mcp.json:
[ { "code": "invalid_union", ... "path": ["command"], "message": "Invalid input: expected string, received undefined" }, { "code": "invalid_value", "values": ["sse", ...
```

As a result the `zapier` MCP server never registers for plugin users — the plugin installs, but its MCP tools are unavailable.

## Root cause
Claude Code validates each `mcpServers` entry against a discriminated union: stdio (`command`) | `{"type": "sse", "url"}` | `{"type": "http", "url"}`. A bare `{"url": ...}` matches no branch of the union. The `type` field is required in every Claude Code version we checked (v2.1.88 → v2.1.163), and all HTTP examples in the official docs carry an explicit `"type": "http"` (https://code.claude.com/docs/en/mcp).

## Fix
One line — add `"type": "http"`. With it the entry matches the http branch of the schema; sibling official plugins (postman, notion, mintlify) already ship `"type": "http"` and load correctly on the same Claude Code versions.