### PR TITLE
Remove broken mcp.json symlink and align app count to 9,000+

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "zapier",
       "source": "./plugins/zapier",
-      "description": "Connect 8,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
+      "description": "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
       "category": "productivity",
       "tags": [
         "zapier",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All through natural language commands—just describe what you want done.
 
 ## Key Features
 
-- **8,000+ App Connections** — Access Zapier's massive library of pre-built integrations
+- **9,000+ App Connections** — Access Zapier's massive library of pre-built integrations
 - **40,000+ Actions** — Enable specific tasks and searches across apps
 - **Natural Language** — No complex commands needed
 - **Secure by Default** — Authentication, encryption, and rate limiting handled by Zapier

--- a/mcp.json
+++ b/mcp.json
@@ -1,1 +1,0 @@
-/Users/brody/git/zapier/zapier-mcp/plugins/zapier/.mcp.json


### PR DESCRIPTION
## Summary

- Removes the root `mcp.json` symlink, which targeted an absolute path on a contributor's machine (`/Users/brody/git/...`) and so dangled in every other checkout (other contributors, GitHub's web UI, CI). No MCP client picks up a bare `mcp.json` at the workspace root — Claude Code reads `.mcp.json`, Cursor reads `.cursor/mcp.json`, Kiro reads `.kiro/settings/mcp.json` — so the file isn't doing anything useful at that path.
- Bumps two stragglers from "8,000+ apps" to "9,000+" so the README Key Features bullet and the `.claude-plugin/marketplace.json` plugin description match the 9,000+ number used everywhere else in the repo and on zapier.com/mcp.

## Test plan

- [x] Verify `mcp.json` is gone from the repo root and the working tree no longer has a dangling symlink
- [x] Spot-check README renders correctly on GitHub and reads "9,000+ App Connections"
- [x] Confirm `.claude-plugin/marketplace.json` is still valid JSON and the plugin description reads "Connect 9,000+ apps"
- [x] Confirm `plugins/zapier/.mcp.json` (the actual plugin MCP config) is untouched