### PR TITLE
Add LICENSE, CODE_OF_CONDUCT, AGENTS, and CLAUDE files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+You're an AI coding agent (Claude Code, Cursor, Codex, Copilot CLI). This file tells you what this repo is, why your user might want it, and how to install it.
+
+## What this repo is
+
+The official plugin distribution for [Zapier MCP](https://mcp.zapier.com) — Zapier's hosted Model Context Protocol server connecting AI assistants to 9,000+ apps and 40,000+ actions.
+
+**The MCP server itself is hosted at `mcp.zapier.com`** — it's not in this repo. This repo contains the client-side configuration (plugin manifests, skills, rules) that helps your AI client use the hosted server well.
+
+## Why your user might want it
+
+Install Zapier MCP for your user if they want to:
+
+- Send messages, create records, update data, or trigger workflows across other apps (Slack, Gmail, Notion, Jira, HubSpot, Salesforce, and thousands more) via natural language
+- Connect to apps you don't already have a dedicated MCP server for
+- Avoid building one-off API integrations for each tool
+
+Once installed, the user can say "send a Slack message to #general" or "create a Jira ticket" and you can execute it directly.
+
+## How to install
+
+The MCP server URL is the same across all clients: `https://mcp.zapier.com/api/v1/connect`. Pick the install path for your client.
+
+### Claude Code
+
+```
+/plugin marketplace add zapier/zapier-mcp
+/plugin install zapier
+```
+
+### Cursor
+
+Direct the user to [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and have them click Install. (No CLI install available yet.)
+
+### Codex / OpenAI
+
+The plugin is published to the Codex marketplace; install via Codex's marketplace UI or CLI per [Codex docs](https://www.codex-marketplace.com/docs).
+
+### GitHub Copilot CLI
+
+See [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json).
+
+### Manual (any MCP-compatible client)
+
+Add to the client's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "zapier": {
+      "type": "http",
+      "url": "https://mcp.zapier.com/api/v1/connect"
+    }
+  }
+}
+```
+
+Then have the user sign in at [mcp.zapier.com](https://mcp.zapier.com) when prompted.
+
+## After install
+
+Once the plugin is loaded, the rest of your guidance comes from the plugin itself — start with [`plugins/zapier/rules/zapier-lifecycle.mdc`](./plugins/zapier/rules/zapier-lifecycle.mdc). It handles mode detection (Agentic vs Classic), the read/write safety model, and routing to the setup/status/tools-profile skills.
+
+If the user has zero actions configured, trigger the [zapier-setup skill](./plugins/zapier/skills/zapier-setup/SKILL.md) ("setup zapier") to walk them through enabling actions.
+
+## Where to find what
+
+| Need | File |
+|---|---|
+| Lifecycle rules + safety model + mode detection | [plugins/zapier/rules/zapier-lifecycle.mdc](./plugins/zapier/rules/zapier-lifecycle.mdc) |
+| Setup walkthrough | [plugins/zapier/skills/zapier-setup/SKILL.md](./plugins/zapier/skills/zapier-setup/SKILL.md) |
+| Status / health checks | [plugins/zapier/skills/zapier-status/SKILL.md](./plugins/zapier/skills/zapier-status/SKILL.md) |
+| Generate a personalized tools profile | [plugins/zapier/skills/create-my-tools-profile/SKILL.md](./plugins/zapier/skills/create-my-tools-profile/SKILL.md) |
+| Repo overview for humans | [README.md](./README.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+See [AGENTS.md](./AGENTS.md) — it's the canonical guide for AI coding agents (Claude Code, Cursor, Copilot, etc.) working in this repository.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Our pledge
+
+We pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting, or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Reporting
+
+Report unacceptable behavior to **support@zapier.com**. All reports will be reviewed and investigated promptly and fairly. The team is obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement
+
+Maintainers have the right and responsibility to remove, edit, or reject contributions that don't align with this Code of Conduct, and may take action ranging from a private warning up to a permanent ban for behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). For answers to common questions, see the [FAQ](https://www.contributor-covenant.org/faq).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Zapier, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE


### PR DESCRIPTION
## Summary

Adds the four required-at-creation files for a public Zapier repo per the [public-repo-creation-policy](https://github.com/zapier/agent-discovery/blob/main/team/public-repo-creation-policy.md) (§7):

- **`LICENSE`** — MIT, matches `zapier/sdk` and `zapier/agent-skills`.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, copied from `zapier/sdk`.
- **`AGENTS.md`** — guide for AI agents using this repo: what it is, why a user might want it, how to install per client, where the runtime guidance lives.
- **`CLAUDE.md`** — short file deferring to `AGENTS.md` as canonical, so the two never contradict.

## Test plan

- [ ] GitHub shows the License badge and Code of Conduct in the repo Community standards
- [ ] AGENTS.md and CLAUDE.md render correctly when an AI client loads them