### PR TITLE
feat: add license and logo to Cursor plugin manifest

### DIFF
--- a/plugins/zapier/.cursor-plugin/plugin.json
+++ b/plugins/zapier/.cursor-plugin/plugin.json
@@ -9,6 +9,7 @@
   },
   "homepage": "https://github.com/zapier/zapier-mcp",
   "repository": "https://github.com/zapier/zapier-mcp",
+  "license": "MIT",
   "category": "productivity",
   "keywords": [
     "zapier",
@@ -32,6 +33,7 @@
     "ai-actions",
     "productivity"
   ],
+  "logo": "assets/logo.svg",
   "skills": "./skills/",
   "rules": "./rules/",
   "mcpServers": "./.mcp.json"


### PR DESCRIPTION
## Summary

Add the two missing top-level fields to `plugins/zapier/.cursor-plugin/plugin.json` that the official [Cursor plugin schema reference](https://cursor.com/docs/reference/plugins) lists and shows in its example:

- `"license": "MIT"` — matches the repo's existing `LICENSE` file.
- `"logo": "assets/logo.svg"` — the asset already ships in `plugins/zapier/assets/` but the manifest didn't reference it. Cursor renders the logo from this field on marketplace cards (resolved against `raw.githubusercontent.com`).

## Why now

We're aligning the repo with vendor-MCP-plugin distribution conventions. Closing small documented gaps like this so Zapier renders correctly next to other plugins in the Cursor marketplace.

## Test plan

- [x] JSON validates locally (verified)
- [x] `assets/logo.svg` exists at the referenced path (verified)
- [x] After merge, the plugin renders with the Zapier logo in the Cursor plugin marketplace card