### PR TITLE
feat: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to Zapier MCP
+
+Thanks for considering a contribution. This repo distributes plugin manifests, skills, and rules for [Zapier MCP](https://zapier.com/mcp) — the server itself is closed source.
+
+**In scope:** fixes to plugin manifests, skills, rules, brand assets, and docs in this repo.
+**Out of scope:** server behavior, app catalog, billing, or auth — file those with [Zapier Support](https://help.zapier.com).
+
+Open a [GitHub Issue](https://github.com/zapier/zapier-mcp/issues) for bugs and proposals, or submit a PR off `main`. AI agents contributing here should start with [AGENTS.md](./AGENTS.md).
+
+This project follows the [Zapier Code of Conduct](https://github.com/zapier/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Add a minimal `CONTRIBUTING.md` at the repo root. ~10 lines, scope-focused.

The one thing this file actually has to do for a plugin distribution repo is keep server / product / billing requests off the issues tracker — those don't belong here. Everything else (PR conventions, skill structure, frontmatter rules) is already covered by `AGENTS.md` and the per-file conventions, so this file just points there.

Modeled loosely on [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers/blob/main/CONTRIBUTING.md) — short, opinionated about scope.

## Why now

Both benchmark repos (Sanity, Atlassian) ship a `CONTRIBUTING.md`; we don't. It's also the file the outside-contributor PR #15 has been trying to add for a month — once this lands we can close #15 with a thank-you.

## Test plan

- [x] Renders cleanly on github.com after merge
- [x] Repo's "Community Standards" page shows ✅ for Contributing
- [x] Close stale PR #15 with a thank-you note pointing at this file