### PR TITLE
feat: refresh README to focus on the repo, not the product

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,25 @@ The MCP server URL is the same across all clients: `https://mcp.zapier.com/api/v
 
 ```
 /plugin marketplace add zapier/zapier-mcp
-/plugin install zapier
+/plugin install zapier@zapier-plugins
 ```
+
+If Anthropic's [`claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) marketplace is already added, skip the first step and run `/plugin install zapier@claude-plugins-official` instead.
 
 ### Cursor
 
-Direct the user to [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and have them click Install. (No CLI install available yet.)
+Direct the user to [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and have them click **Install**. (No CLI install available yet.)
 
 ### GitHub Copilot CLI
 
-See [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json).
+```
+copilot plugin marketplace add zapier/zapier-mcp
+copilot plugin install zapier@zapier-plugins
+```
+
+### Kiro
+
+Direct the user to [kiro.dev/powers](https://kiro.dev/powers), find Zapier, and click **Add to Kiro**. Powers register through the IDE — no command-line setup.
 
 ### Manual (any MCP-compatible client)
 
@@ -68,4 +77,10 @@ If the user has zero actions configured, trigger the [zapier-setup skill](./plug
 | Setup walkthrough | [plugins/zapier/skills/zapier-setup/SKILL.md](./plugins/zapier/skills/zapier-setup/SKILL.md) |
 | Status / health checks | [plugins/zapier/skills/zapier-status/SKILL.md](./plugins/zapier/skills/zapier-status/SKILL.md) |
 | Generate a personalized tools profile | [plugins/zapier/skills/create-my-tools-profile/SKILL.md](./plugins/zapier/skills/create-my-tools-profile/SKILL.md) |
+| Claude Code plugin manifest | [plugins/zapier/.claude-plugin/plugin.json](./plugins/zapier/.claude-plugin/plugin.json) |
+| Cursor plugin manifest | [plugins/zapier/.cursor-plugin/plugin.json](./plugins/zapier/.cursor-plugin/plugin.json) |
+| GitHub Copilot CLI plugin manifest | [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json) |
+| Kiro Power manifest | [POWER.md](./POWER.md) |
+| LLM discovery index | [llms.txt](./llms.txt) |
 | Repo overview for humans | [README.md](./README.md) |
+| How to contribute | [CONTRIBUTING.md](./CONTRIBUTING.md) |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The hosted server lives at `mcp.zapier.com/api/v1/connect` and is closed source.
 
 ## What's in this repo
 
-- **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json) and [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), under `plugins/zapier/`
+- **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`
+- **A Kiro Power manifest** at [`POWER.md`](./POWER.md) for [Kiro.dev](https://kiro.dev) consumption
 - **Onboarding skills** for auth, action selection, and health checks ([`skills/`](./plugins/zapier/skills/))
 - **Lifecycle rules** covering server-mode detection and the read/write safety model ([`zapier-lifecycle.mdc`](./plugins/zapier/rules/zapier-lifecycle.mdc))
 - **Brand assets** ([`assets/`](./plugins/zapier/assets/))
@@ -23,14 +24,33 @@ For a routing guide to specific skills, rules, and manifests, see [AGENTS.md](./
 
 ### Claude Code
 
+If you've already added Anthropic's official Claude Code plugin marketplace ([`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official)), install directly:
+
+```
+/plugin install zapier@claude-plugins-official
+```
+
+Otherwise, add this repo as the marketplace first:
+
 ```
 /plugin marketplace add zapier/zapier-mcp
-/plugin install zapier
+/plugin install zapier@zapier-plugins
 ```
 
 ### Cursor
 
 Open [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and click **Install**.
+
+### GitHub Copilot CLI
+
+```
+copilot plugin marketplace add zapier/zapier-mcp
+copilot plugin install zapier@zapier-plugins
+```
+
+### Kiro
+
+Browse to [kiro.dev/powers](https://kiro.dev/powers), find Zapier, and click **Add to Kiro**. Powers register through the IDE — no command-line setup. The catalog entry is mirrored at [`kirodotdev/powers`](https://github.com/kirodotdev/powers).
 
 ### Any other MCP-compatible client
 
@@ -58,6 +78,15 @@ Then sign in at [mcp.zapier.com](https://mcp.zapier.com) when prompted.
 1. **Enable actions** at [mcp.zapier.com](https://mcp.zapier.com) — each enabled action becomes a tool your AI can call.
 2. **Trust but verify writes.** The lifecycle rules require explicit user confirmation before any write action runs. Read actions don't need confirmation.
 3. **Run a health check.** Ask your agent to "check Zapier status" to invoke the [`zapier-status` skill](./plugins/zapier/skills/zapier-status/SKILL.md) and see what's configured.
+
+## Downstream marketplaces
+
+This repo is the source of truth for the plugin. It's also vendored or mirrored into the following marketplaces:
+
+- [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) — Anthropic's curated Claude Code marketplace (vendors `plugins/zapier/` via `git-subdir` pinned to `main`)
+- [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins) — Anthropic's Claude Cowork marketplace (vendors `plugins/zapier/` via `git-subdir` pinned to `main`)
+- [`kirodotdev/powers`](https://github.com/kirodotdev/powers) — Kiro's Powers catalog, browsable at [kiro.dev/powers](https://kiro.dev/powers); mirrors `POWER.md` and the steering files
+- [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier) — Cursor's MCP server registry, surfaced at [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier)
 
 ## Documentation & support
 

--- a/README.md
+++ b/README.md
@@ -1,125 +1,72 @@
-# Zapier MCP
+# zapier-mcp
 
-**Connect your AI to thousands of apps with the Model Context Protocol**
+> Official plugin distribution for [Zapier MCP](https://zapier.com/mcp). Install the plugin in your AI client and your agent gains access to 9,000+ apps and 40,000+ actions via Zapier's hosted Model Context Protocol server.
 
-Transform your AI assistant from a conversational tool into a functional extension of your applications. [Zapier MCP](https://zapier.com/mcp) is a **remote** MCP server that gives your AI direct access to 9,000+ apps and 40,000+ actions—no complex API integrations required.
+The hosted server lives at `mcp.zapier.com/api/v1/connect` and is closed source. This repo is the discovery and installation surface: plugin manifests, onboarding skills, and lifecycle rules that help your AI client use the server correctly from the first call.
 
-https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
+## What's in this repo
 
----
+- **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json) and [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), under `plugins/zapier/`
+- **Onboarding skills** for auth, action selection, and health checks ([`skills/`](./plugins/zapier/skills/))
+- **Lifecycle rules** covering server-mode detection and the read/write safety model ([`zapier-lifecycle.mdc`](./plugins/zapier/rules/zapier-lifecycle.mdc))
+- **Brand assets** ([`assets/`](./plugins/zapier/assets/))
 
-## What is Zapier MCP?
+What's **not** here:
 
-[Zapier MCP](https://zapier.com/mcp) is a standardized way to connect AI assistants to thousands of apps and services. It enables your AI to take real actions like:
+- The MCP server itself — hosted at `mcp.zapier.com` (closed source)
+- The action catalog — managed at [mcp.zapier.com](https://mcp.zapier.com)
+- Product documentation — at [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md)
 
-- 💬 Send Slack messages and create channels
-- 📊 Add rows to Google Sheets and create spreadsheets
-- 📧 Send Gmail emails and manage labels
-- ✅ Create Asana tasks and update projects
-- 🐙 Create GitHub issues and manage PRs
-- 📈 Update HubSpot deals and manage contacts
+For a routing guide to specific skills, rules, and manifests, see [AGENTS.md](./AGENTS.md).
 
-All through natural language commands—just describe what you want done.
+## Install
 
----
+### Claude Code
 
-## Key Features
+```
+/plugin marketplace add zapier/zapier-mcp
+/plugin install zapier
+```
 
-- **9,000+ App Connections** — Access Zapier's massive library of pre-built integrations
-- **40,000+ Actions** — Enable specific tasks and searches across apps
-- **Natural Language** — No complex commands needed
-- **Secure by Default** — Authentication, encryption, and rate limiting handled by Zapier
-- **Multiple Client Support** — Works with Claude, ChatGPT, Cursor, Windsurf, and more
+### Cursor
 
----
+Open [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and click **Install**.
 
-## Getting Started
+### Any other MCP-compatible client
 
-**1. Generate your credentials**
+Add to your client's MCP config:
 
-Visit [mcp.zapier.com](https://mcp.zapier.com) to set up your server. Two auth options are available:
+```json
+{
+  "mcpServers": {
+    "zapier": {
+      "type": "http",
+      "url": "https://mcp.zapier.com/api/v1/connect"
+    }
+  }
+}
+```
 
-- **API Key** — Best for personal use and local development. Generate one at [mcp.zapier.com](https://mcp.zapier.com).
-- **OAuth** — Best for building apps where end users connect their own Zapier account. Use the connect URL: `https://mcp.zapier.com/api/v1/connect`
+Then sign in at [mcp.zapier.com](https://mcp.zapier.com) when prompted.
 
-**2. Connect your MCP client**
+## Zapier MCP, briefly
 
-Point your AI client at your Zapier MCP server URL. See client-specific setup guides at [mcp.zapier.com](https://mcp.zapier.com).
+[Zapier MCP](https://zapier.com/mcp) is a hosted Model Context Protocol server that connects AI assistants to 9,000+ apps. Servers run in one of two modes — **Agentic** (action discovery and execution managed in chat through built-in meta-tools) or **Classic** (each enabled action exposed as a dedicated tool). For the full mode-specific built-in tool reference and product overview, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
 
-**3. Add actions to your server**
+## After install
 
-Visit [mcp.zapier.com](https://mcp.zapier.com) to browse and enable specific actions. Each action you add becomes a callable tool in your AI client.
+1. **Enable actions** at [mcp.zapier.com](https://mcp.zapier.com) — each enabled action becomes a tool your AI can call.
+2. **Trust but verify writes.** The lifecycle rules require explicit user confirmation before any write action runs. Read actions don't need confirmation.
+3. **Run a health check.** Ask your agent to "check Zapier status" to invoke the [`zapier-status` skill](./plugins/zapier/skills/zapier-status/SKILL.md) and see what's configured.
 
----
+## Documentation & support
 
-## Built-in Tools
-
-Zapier MCP servers operate in one of two modes. Your server's mode determines which built-in tools are available.
-
-### Agentic (Beta)
-
-The Agentic configuration is currently in Beta and being rolled out to all users. Agentic servers provide 14 static meta-tools for managing and executing actions entirely within the chat experience:
-
-| Tool | Category | Description |
-|------|----------|-------------|
-| `list_enabled_zapier_actions` | Action Management | See all your currently enabled actions |
-| `discover_zapier_actions` | Action Management | Search for apps and actions available to add |
-| `enable_zapier_action` | Action Management | Enable a specific action as a tool |
-| `disable_zapier_action` | Action Management | Disable an action you no longer need |
-| `auto_provision_mcp` | Action Management | Auto-setup tools from your existing Zapier connections |
-| `execute_zapier_read_action` | Execution | Run a read/search action (e.g., find an email, look up a contact) |
-| `execute_zapier_write_action` | Execution | Run a write action (e.g., send a message, create a task) |
-| `get_configuration_url` | Configuration | Get the URL to your Zapier MCP config page |
-| `list_zapier_skills` | Skills | List saved Zapier skills/workflows |
-| `get_zapier_skill` | Skills | Retrieve a specific skill |
-| `create_zapier_skill` | Skills | Create a new skill |
-| `update_zapier_skill` | Skills | Update an existing skill |
-| `delete_zapier_skill` | Skills | Delete a skill |
-| `send_feedback` | Feedback | Send feedback to Zapier |
-
-### Classic
-
-Classic servers expose one built-in tool alongside your configured action tools:
-
-| Tool | Description |
-|------|-------------|
-| `get_configuration_url` | Returns the URL to add/edit/remove actions from this server |
+- **Product overview**: [zapier.com/mcp](https://zapier.com/mcp)
+- **Documentation**: [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md)
+- **Support**: [help.zapier.com](https://help.zapier.com)
+- **For AI agents working in this repo**: [AGENTS.md](./AGENTS.md)
+- **For contributors**: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ---
 
-## How Actions Work
-
-### Agentic (Beta)
-
-Actions are managed and executed directly in chat. Use `discover_zapier_actions` to find available apps, `enable_zapier_action` to add one, and `execute_zapier_read_action` / `execute_zapier_write_action` to run it. Your AI can also call `list_enabled_zapier_actions` at any time to see what's currently available.
-
-### Classic
-
-When you add an action at [mcp.zapier.com](https://mcp.zapier.com), it gets exposed as a dedicated tool on your MCP server. Your AI can then call it directly.
-
-**Example:** Enable the "Gmail - Send Email" action, and your AI gains a `gmail_send_email` tool it can invoke with the right parameters (to, subject, body) whenever you ask it to send an email.
-
-The more actions you enable, the more capable your AI becomes. You can build a focused server with just a handful of tools, or a broad one that spans your entire stack.
-
----
-
-## Plugins
-
-This repo also hosts official Zapier plugins for AI workflows. Each plugin is a standalone directory under `plugins/` with its own manifest.
-
-| Plugin | Category | Description |
-|--------|----------|-------------|
-| [Zapier](plugins/zapier/) | Productivity | Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client. Includes onboarding skills, status tools, and safety rules. |
-
----
-
-## Resources
-
-- **[🤖 MCP Plugins →](plugins/)** — Official plugins in this repo
-- **[🤖 MCP Skills →](plugins/zapier/skills/)** — Companion skills for AI clients
-- **[📖 Developer Documentation →](https://docs.zapier.com/mcp/home)** — API references and integration guides
-- **[🆘 Support →](https://mcp.zapier.app/home)** — Get help with Zapier MCP
-
----
-
-*Zapier MCP is part of the [Model Context Protocol](https://modelcontextprotocol.io/) ecosystem*
+*Zapier MCP is part of the [Model Context Protocol](https://modelcontextprotocol.io/) ecosystem.*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 The hosted server lives at `mcp.zapier.com/api/v1/connect` and is closed source. This repo is the discovery and installation surface: plugin manifests, onboarding skills, and lifecycle rules that help your AI client use the server correctly from the first call.
 
+## About Zapier MCP
+
+[Zapier MCP](https://zapier.com/mcp) is a hosted Model Context Protocol server that connects AI assistants to 9,000+ apps. Servers run in one of two modes:
+
+- **Agentic** — Action discovery and execution are managed in chat through built-in meta-tools.
+- **Classic** — Each enabled action is exposed as a dedicated tool named `app_action_name`.
+
+The plugin in this repo detects which mode you're on and routes accordingly. For the full mode-specific built-in tool reference and product overview, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
+
 ## What's in this repo
 
 - **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`
@@ -68,10 +77,6 @@ Add to your client's MCP config:
 ```
 
 Then sign in at [mcp.zapier.com](https://mcp.zapier.com) when prompted.
-
-## Zapier MCP, briefly
-
-[Zapier MCP](https://zapier.com/mcp) is a hosted Model Context Protocol server that connects AI assistants to 9,000+ apps. Servers run in one of two modes — **Agentic** (action discovery and execution managed in chat through built-in meta-tools) or **Classic** (each enabled action exposed as a dedicated tool). For the full mode-specific built-in tool reference and product overview, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
 
 ## After install
 

--- a/plugins/zapier/README.md
+++ b/plugins/zapier/README.md
@@ -1,19 +1,19 @@
 # Zapier Plugin
 
-Connect 9,000+ apps to your AI workflow. Configure your actions at mcp.zapier.com, and each one becomes a tool your AI can call directly — no config files, no tokens, no setup scripts.
+Connects your AI client to [Zapier MCP](https://zapier.com/mcp) — Zapier's hosted Model Context Protocol server. Configure your actions at [mcp.zapier.com](https://mcp.zapier.com), and each one becomes a tool your AI can call directly.
 
 ## Quick Start
 
-After installing:
+After installing the plugin:
 
 1. Connect the Zapier MCP server in your client's settings:
    - **Cursor:** Settings > Cursor Settings > Tools & MCP > click **Connect**
    - **Claude Desktop:** Customize > Connectors > Zapier > click **Connect**
-   - **Other clients:** Find the Zapier MCP server in your MCP settings and connect
+   - **Other clients:** find the Zapier MCP server in your MCP settings and connect
 2. Sign in to your Zapier account when prompted
 3. Open a chat and say **"setup zapier"** to get started
 
-Your server will be in one of two modes — the plugin detects which one automatically and guides you through the right flow.
+The plugin auto-detects your server mode and routes to the right onboarding flow.
 
 ## What's Included
 
@@ -24,34 +24,20 @@ Your server will be in one of two modes — the plugin detects which one automat
 | **zapier-status** skill           | Three modes: health check (dashboard of connected tools), audit (find duplicates and waste), diagnose (systematic troubleshooting).                               |
 | **create-my-tools-profile** skill | Scans your configured action tools and generates a personalized tools profile so your AI knows what tools you have and when to use them.                          |
 
-## How Tools Work
+## Server modes
 
-Zapier MCP operates in one of two modes depending on your server configuration. The plugin detects the mode automatically.
+Zapier MCP servers run in one of two modes; the plugin detects which automatically.
 
-### Agentic (Beta)
+- **Agentic** — Action discovery and execution are managed in chat through built-in meta-tools (`list_enabled_zapier_actions`, `discover_zapier_actions`, `execute_zapier_read_action`, etc.).
+- **Classic** — Each enabled action is exposed as a dedicated tool named `app_action_name` (e.g., `gmail_send_email`, `slack_find_message`).
 
-The Agentic configuration is currently in Beta and being rolled out to all users. In this mode, your server provides 14 static meta-tools for managing and executing actions directly in chat. You can discover apps, enable/disable actions, and execute reads and writes without leaving the conversation. Onboarding is handled by a Zapier-hosted skill — just say "setup zapier" and the plugin will walk you through it.
-
-Key tools: `list_enabled_zapier_actions`, `discover_zapier_actions`, `enable_zapier_action`, `execute_zapier_read_action`, `execute_zapier_write_action`, `list_zapier_skills`, `get_zapier_skill`, and more.
-
-### Classic
-
-In Classic mode, each action you configure at [mcp.zapier.com](https://mcp.zapier.com) becomes its own MCP tool, named with the pattern `app_action_name`:
-
-- **`gmail_send_email`** — Send an email via Gmail
-- **`slack_find_message`** — Search for a Slack message
-- **`jira_create_issue`** — Create a Jira issue
-- **`google_calendar_find_events`** — Look up calendar events
-
-There is also one built-in tool:
-
-- **`get_configuration_url`** — Returns the URL to manage your actions (add, remove, authenticate)
+For the full mode-specific tool reference, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
 
 ## Links
 
 - [Zapier MCP Dashboard](https://mcp.zapier.com) — Manage your server, authenticate apps, view connected tools
-- [Zapier](https://zapier.com) — Learn more about Zapier
-- [Zapier Status](https://status.zapier.com) — Check for outages
+- [Zapier MCP documentation](https://docs.zapier.com/mcp/home.md) — Full product docs
+- [Zapier status](https://status.zapier.com) — Check for outages
 
 ## Support
 

--- a/plugins/zapier/README.md
+++ b/plugins/zapier/README.md
@@ -7,9 +7,9 @@ Connects your AI client to [Zapier MCP](https://zapier.com/mcp) — Zapier's hos
 After installing the plugin:
 
 1. Connect the Zapier MCP server in your client's settings:
-   - **Cursor:** Settings > Cursor Settings > Tools & MCP > click **Connect**
-   - **Claude Desktop:** Customize > Connectors > Zapier > click **Connect**
-   - **Other clients:** find the Zapier MCP server in your MCP settings and connect
+   - **Cursor:** Settings → Cursor Settings → Tools & MCP → click **Connect**
+   - **Claude Desktop:** Customize → Connectors → Zapier → click **Connect**
+   - **Other clients:** Find the Zapier MCP server in your MCP settings and click Connect
 2. Sign in to your Zapier account when prompted
 3. Open a chat and say **"setup zapier"** to get started
 


### PR DESCRIPTION
## Summary

Restructure the repo's two READMEs (root and per-plugin) so they document *this repo* instead of duplicating Zapier MCP product content already maintained at `zapier.com/mcp` and `docs.zapier.com/mcp`, then expand the root README's install surface to cover every downstream consumer.

Both READMEs had the same problem: they read like Zapier MCP product manuals — sales-flavored openings, key-features bullets, detailed Agentic vs. Classic tool tables, "How Actions Work" examples. None of that is unique to this repo, and all of it is at risk of drifting from the canonical product docs.

This repo's actual job is narrower: **discovery and installation of the Zapier plugin for AI clients.** The new READMEs reflect that.

### Root `README.md`

- Lead with what this repo is and isn't
- Expand `## What's in this repo` to name the Copilot CLI manifest and `POWER.md` (the Kiro Power manifest)
- Surface install for every supported client:
  - **Claude Code** — two paths: install from `anthropics/claude-plugins-official` if added, otherwise add this repo as a marketplace
  - **Cursor** — `cursor.com/marketplace/zapier`
  - **GitHub Copilot CLI** — `copilot plugin marketplace add zapier/zapier-mcp` + `copilot plugin install zapier@zapier-plugins`
  - **Kiro** — browse to `kiro.dev/powers` and click Add
  - **Any other MCP-compatible client** — raw `mcpServers` config block
- Add a `## Downstream marketplaces` section naming the four registries that vendor or mirror this plugin: `anthropics/claude-plugins-official`, `anthropics/knowledge-work-plugins`, `kirodotdev/powers`, `cursor/mcp-servers`
- One short paragraph of Zapier MCP context that links out to `docs.zapier.com/mcp/home.md` for the full product reference (including the Agentic / Classic mode tables that used to be inlined here)
- Brief "after install" guidance pointing at the safety model and the `zapier-status` skill
- Trim repo-layout duplication — `AGENTS.md` already covers routing

### `plugins/zapier/README.md`

Same restructure: replace the inlined Agentic vs Classic tool tables with a short "Server modes" summary that links to `docs.zapier.com/mcp/home.md`. Add a missing docs link to the Links section. Kept: title, Quick Start (plugin-specific install steps), "What's Included" component table, Links, Support.

### Across both

Links to `docs.zapier.com` use the `.md` mirror URLs so agents can fetch markdown directly instead of parsing rendered HTML.

## Test plan

- [ ] Renders cleanly on github.com after merge
- [ ] Every internal link resolves (skills, rules, manifests, `POWER.md`)
- [ ] Every external `docs.zapier.com/*.md` link returns markdown
- [ ] `/plugin install zapier@claude-plugins-official` resolves once the official marketplace is added
- [ ] `/plugin marketplace add zapier/zapier-mcp` + `/plugin install zapier@zapier-plugins` works end-to-end in Claude Code
- [ ] `copilot plugin marketplace add zapier/zapier-mcp` + `copilot plugin install zapier@zapier-plugins` works end-to-end in Copilot CLI
- [ ] Kiro **Add to Kiro** flow from `kiro.dev/powers` installs the Zapier power
- [ ] Cursor install via `cursor.com/marketplace/zapier` works end-to-end

## Follow-ups (out of scope for this PR)

- **`cursor/mcp-servers/servers/zapier/server.json` is hand-maintained and drifting from this repo.** Description currently reads "8,000+ apps" vs. this repo's "9,000+", and the config URL is templated. Either keep it in sync manually or open a PR upstream to align copy.