### PR TITLE
docs: clarify that the plugin registers the MCP server entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
 
 ## What's in this repo
 
-- **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`
+- **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`. Installing the plugin also registers the hosted MCP server with your client — that's why `zapier` shows up under `/mcp` after install, via [`.mcp.json`](./plugins/zapier/.mcp.json).
 - **A Kiro Power manifest** at [`POWER.md`](./POWER.md) for [Kiro.dev](https://kiro.dev) consumption
 - **Onboarding skills** for auth, action selection, and health checks ([`skills/`](./plugins/zapier/skills/))
 - **Lifecycle rules** covering server-mode detection and the read/write safety model ([`zapier-lifecycle.mdc`](./plugins/zapier/rules/zapier-lifecycle.mdc))


### PR DESCRIPTION
## Summary

- Adds a one-line clarification to the "What's in this repo" manifests bullet explaining that installing the plugin also registers the hosted MCP server with the client
- Points readers at [`plugins/zapier/.mcp.json`](./plugins/zapier/.mcp.json) so they can see the actual registration

The previous wording described the manifests as just plugin metadata, which left readers wondering where `zapier` in their `/mcp` list came from. It comes from this repo, via the plugin's `.mcp.json`.

## Test plan

- [ ] Renders cleanly on github.com after merge
- [ ] `.mcp.json` link resolves