### PR TITLE
feat: add server.json for MCP Registry discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ If the user has zero actions configured, trigger the [zapier-setup skill](./plug
 | Cursor plugin manifest | [plugins/zapier/.cursor-plugin/plugin.json](./plugins/zapier/.cursor-plugin/plugin.json) |
 | GitHub Copilot CLI plugin manifest | [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json) |
 | Kiro Power manifest | [POWER.md](./POWER.md) |
+| MCP Registry manifest | [server.json](./server.json) |
 | LLM discovery index | [llms.txt](./llms.txt) |
 | Repo overview for humans | [README.md](./README.md) |
 | How to contribute | [CONTRIBUTING.md](./CONTRIBUTING.md) |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
 
 - **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`. Installing the plugin also registers the hosted MCP server with your client — that's why `zapier` shows up under `/mcp` after install, via [`.mcp.json`](./plugins/zapier/.mcp.json).
 - **A Kiro Power manifest** at [`POWER.md`](./POWER.md) for [Kiro.dev](https://kiro.dev) consumption
+- **An MCP Registry manifest** at [`server.json`](./server.json) so the hosted server is discoverable in the [official MCP Registry](https://registry.modelcontextprotocol.io)
 - **Onboarding skills** for auth, action selection, and health checks ([`skills/`](./plugins/zapier/skills/))
 - **Lifecycle rules** covering server-mode detection and the read/write safety model ([`zapier-lifecycle.mdc`](./plugins/zapier/rules/zapier-lifecycle.mdc))
 - **Brand assets** ([`assets/`](./plugins/zapier/assets/))

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ Per-client install manifests live under `plugins/zapier/`. Each surfaces the sam
 - [MCP server config](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.mcp.json): Generic `mcpServers` declaration with `"type": "http"`.
 - [Claude marketplace registry](https://github.com/zapier/zapier-mcp/blob/main/.claude-plugin/marketplace.json): Top-level marketplace entry pointing at `plugins/zapier`.
 - [Cursor marketplace registry](https://github.com/zapier/zapier-mcp/blob/main/.cursor-plugin/marketplace.json): Top-level marketplace entry pointing at `plugins/zapier`.
+- [MCP Registry manifest](https://github.com/zapier/zapier-mcp/blob/main/server.json): `server.json` for the [official MCP Registry](https://registry.modelcontextprotocol.io) catalog.
 
 ## Skills
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "com.zapier/mcp",
+  "title": "Zapier MCP Server",
+  "description": "Connect 9,000+ apps to your AI workflow via Zapier's hosted MCP server.",
+  "websiteUrl": "https://zapier.com/mcp",
+  "repository": {
+    "url": "https://github.com/zapier/zapier-mcp",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.zapier.com/api/v1/connect"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `server.json` at the repo root following the official [MCP server schema](https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json), so the hosted Zapier MCP server can be listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) catalog.
- Links the new file from `AGENTS.md`, `README.md`, and `llms.txt` so it sits alongside the other manifests in the discovery surfaces.

The manifest is self-contained — it inlines the server URL (`https://mcp.zapier.com/api/v1/connect`) and metadata. It does not replace or modify the existing `plugins/zapier/.mcp.json`, which remains the client-facing plugin config.

Inspired by [`figma/mcp-server-guide`](https://github.com/figma/mcp-server-guide/blob/main/server.json), which uses the same pattern.

## Test plan

- [ ] Validate JSON against the published schema (`https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json`)
- [ ] Confirm `name` (`com.zapier/mcp`), `description` length, and `version` satisfy schema constraints
- [ ] Verify links in README, AGENTS.md, and llms.txt render correctly on GitHub