### PR TITLE
fix: repoint zapier-power steering symlinks to two-level relative paths

### DIFF
--- a/zapier-power/steering/create-my-tools-profile.md
+++ b/zapier-power/steering/create-my-tools-profile.md
@@ -1,1 +1,1 @@
-../plugins/zapier/skills/create-my-tools-profile/SKILL.md
+../../plugins/zapier/skills/create-my-tools-profile/SKILL.md

--- a/zapier-power/steering/zapier-setup.md
+++ b/zapier-power/steering/zapier-setup.md
@@ -1,1 +1,1 @@
-../plugins/zapier/skills/zapier-setup/SKILL.md
+../../plugins/zapier/skills/zapier-setup/SKILL.md

--- a/zapier-power/steering/zapier-status.md
+++ b/zapier-power/steering/zapier-status.md
@@ -1,1 +1,1 @@
-../plugins/zapier/skills/zapier-status/SKILL.md
+../../plugins/zapier/skills/zapier-status/SKILL.md


### PR DESCRIPTION
## Summary

PR #32 moved `steering/` into `zapier-power/steering/`, but the symlinks under that directory retained their original target text (`../plugins/...`). Since the files are now one level deeper, the targets need to be `../../plugins/...` to resolve correctly.

Before this fix, the three steering symlinks resolved to non-existent paths:

\`\`\`
$ cat zapier-power/steering/zapier-setup.md
cat: No such file or directory
\`\`\`

After:

\`\`\`
$ cat zapier-power/steering/zapier-setup.md
---
name: zapier-setup
description: Set up Zapier MCP and add tools to your AI assistant...
\`\`\`

## Test plan

- [x] `cat zapier-power/steering/zapier-setup.md` resolves to skill content
- [x] `cat zapier-power/steering/zapier-status.md` resolves to skill content
- [x] `cat zapier-power/steering/create-my-tools-profile.md` resolves to skill content