### PR TITLE
feat: add Gemini CLI extension manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,14 @@ copilot plugin marketplace add zapier/zapier-mcp
 copilot plugin install zapier@zapier-plugins
 ```
 
+### Gemini CLI
+
+```
+gemini extensions install https://github.com/zapier/zapier-mcp
+```
+
+After install, the user authenticates inside Gemini with `/mcp auth zapier`.
+
 ### Kiro
 
 Direct the user to [kiro.dev/powers](https://kiro.dev/powers), find Zapier, and click **Add to Kiro**. Powers register through the IDE — no command-line setup.
@@ -84,6 +92,7 @@ Any `https://docs.zapier.com/<path>` page has a raw-markdown mirror — append `
 | Claude Code plugin manifest | [plugins/zapier/.claude-plugin/plugin.json](./plugins/zapier/.claude-plugin/plugin.json) |
 | Cursor plugin manifest | [plugins/zapier/.cursor-plugin/plugin.json](./plugins/zapier/.cursor-plugin/plugin.json) |
 | GitHub Copilot CLI plugin manifest | [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json) |
+| Gemini CLI extension manifest | [gemini-extension.json](./gemini-extension.json) |
 | Kiro Power manifest + steering | [zapier-power/](./zapier-power/) |
 | MCP Registry manifest | [server.json](./server.json) |
 | LLM discovery index | [llms.txt](./llms.txt) |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
 ## What's in this repo
 
 - **Per-client plugin manifests** for [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), under `plugins/zapier/`. Installing the plugin also registers the hosted MCP server with your client — that's why `zapier` shows up under `/mcp` after install, via [`.mcp.json`](./plugins/zapier/.mcp.json).
+- **A Gemini CLI extension manifest** at [`gemini-extension.json`](./gemini-extension.json) so users can install with `gemini extensions install`
 - **A Kiro Power bundle** under [`zapier-power/`](./zapier-power/) — `POWER.md` manifest, scoped `mcp.json`, and `steering/` files for [Kiro.dev](https://kiro.dev) consumption
 - **An MCP Registry manifest** at [`server.json`](./server.json) so the hosted server is discoverable in the [official MCP Registry](https://registry.modelcontextprotocol.io)
 - **Onboarding skills** for auth, action selection, and health checks ([`skills/`](./plugins/zapier/skills/))
@@ -59,6 +60,14 @@ Open [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier) and 
 copilot plugin marketplace add zapier/zapier-mcp
 copilot plugin install zapier@zapier-plugins
 ```
+
+### Gemini CLI
+
+```
+gemini extensions install https://github.com/zapier/zapier-mcp
+```
+
+Authenticate inside Gemini with `/mcp auth zapier`. The catalog entry is `gemini-extension.json` at the repo root.
 
 ### Kiro
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,13 @@
+{
+  "name": "zapier",
+  "version": "1.0.0",
+  "description": "Connect 9,000+ apps to your AI workflow via Zapier MCP — discover, enable, and execute Zapier actions directly from Gemini CLI.",
+  "mcpServers": {
+    "zapier": {
+      "httpUrl": "https://mcp.zapier.com/api/v1/connect",
+      "oauth": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ Per-client install manifests live under `plugins/zapier/`. Each surfaces the sam
 - [MCP server config](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.mcp.json): Generic `mcpServers` declaration with `"type": "http"`.
 - [Claude marketplace registry](https://github.com/zapier/zapier-mcp/blob/main/.claude-plugin/marketplace.json): Top-level marketplace entry pointing at `plugins/zapier`.
 - [Cursor marketplace registry](https://github.com/zapier/zapier-mcp/blob/main/.cursor-plugin/marketplace.json): Top-level marketplace entry pointing at `plugins/zapier`.
+- [Gemini CLI extension manifest](https://github.com/zapier/zapier-mcp/blob/main/gemini-extension.json): `gemini-extension.json` for `gemini extensions install` from the GitHub URL.
 - [MCP Registry manifest](https://github.com/zapier/zapier-mcp/blob/main/server.json): `server.json` for the [official MCP Registry](https://registry.modelcontextprotocol.io) catalog.
 
 ## Skills


### PR DESCRIPTION
## Summary

Adds `gemini-extension.json` at the repo root so users can install Zapier MCP via Gemini CLI.

**Once merged**, the install command is:

```
gemini extensions install https://github.com/zapier/zapier-mcp
```

**To test this branch before merging**:

```
gemini extensions install --consent https://github.com/zapier/zapier-mcp --ref feat/add-gemini-extension
```

Format follows [Gemini's extension reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/reference.md) — `httpUrl` for the MCP endpoint (Gemini's convention for HTTP servers) and `oauth.enabled: true` to trigger the OAuth flow against `mcp.zapier.com`. Inspired by [figma/mcp-server-guide's gemini-extension.json](https://github.com/figma/mcp-server-guide/blob/main/gemini-extension.json).

Also adds the Gemini CLI install path to `README.md`, `AGENTS.md`, and `llms.txt`.

## Status: draft

Schema validation passes (`gemini extensions validate /path/to/repo` reports success) and local `extensions link` resolves the manifest. **Not yet end-to-end tested** — the OAuth round-trip against `mcp.zapier.com/api/v1/connect` from a Gemini session needs a human at the keyboard. Marking ready-for-review after the test plan below comes back clean.

## Test plan

Prereq: `brew install gemini-cli` (tested on 0.46.0).

**1. Schema validation (passes)**

```bash
gemini extensions validate /path/to/this/checkout
# → "Extension /path/to/checkout has been successfully validated."
```

**2. Local install from checkout** (most useful while iterating on the manifest)

```bash
# From a clean state:
gemini extensions uninstall zapier 2>/dev/null
gemini extensions link --consent /path/to/this/checkout
gemini extensions list   # → "✓ zapier (1.0.0)" with "MCP servers: zapier"
```

**3. Install from this branch on GitHub** (what real users will hit post-merge)

```bash
gemini extensions uninstall zapier
gemini extensions install --consent https://github.com/zapier/zapier-mcp --ref feat/add-gemini-extension
gemini extensions list
```

**4. OAuth + tool exposure inside Gemini** (the actual blocker for merging)

Launch `gemini` and run:

```
/extensions list           # confirms "zapier" present and enabled
/mcp auth zapier           # opens mcp.zapier.com OAuth — sign in
/mcp                       # confirm "zapier" appears with tools listed
```

**5. Smoke a tool**

With at least one action enabled at mcp.zapier.com, ask Gemini to do something concrete — e.g. *"List my enabled Zapier actions"* (Agentic mode) or *"What's the configuration URL for Zapier?"* (Classic mode). Confirm Gemini calls the tool and the response is non-empty.

## Notes

- `httpUrl` (not `url` + `type: http`) is intentional — that's Gemini's documented field name for HTTP MCP servers in extension manifests.
- This is purely additive — no existing client paths are touched.
