### PR TITLE
feat: add _meta.ideToolTitles to plugin .mcp.json

### DIFF
--- a/plugins/zapier/.mcp.json
+++ b/plugins/zapier/.mcp.json
@@ -2,7 +2,26 @@
   "mcpServers": {
     "zapier": {
       "type": "http",
-      "url": "https://mcp.zapier.com/api/v1/connect"
+      "url": "https://mcp.zapier.com/api/v1/connect",
+      "_meta": {
+        "ideToolIconPath": "./assets/icon.svg",
+        "ideToolTitles": {
+          "list_enabled_zapier_actions": "List Enabled Actions",
+          "discover_zapier_actions": "Discover Actions",
+          "enable_zapier_action": "Enable Action",
+          "disable_zapier_action": "Disable Action",
+          "auto_provision_mcp": "Auto-Provision Tools",
+          "execute_zapier_read_action": "Execute Read Action",
+          "execute_zapier_write_action": "Execute Write Action",
+          "get_configuration_url": "Get Configuration URL",
+          "list_zapier_skills": "List Saved Skills",
+          "get_zapier_skill": "Get Saved Skill",
+          "create_zapier_skill": "Create Saved Skill",
+          "update_zapier_skill": "Update Saved Skill",
+          "delete_zapier_skill": "Delete Saved Skill",
+          "send_feedback": "Send Feedback"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `_meta.ideToolTitles` and `_meta.ideToolIconPath` to the `zapier` server entry in `plugins/zapier/.mcp.json` so IDE-based MCP clients can render the 14 stable Agentic-mode meta-tools with human-readable titles instead of raw snake_case names.

| Raw tool name | Display title |
|---|---|
| `list_enabled_zapier_actions` | List Enabled Actions |
| `discover_zapier_actions` | Discover Actions |
| `enable_zapier_action` | Enable Action |
| `disable_zapier_action` | Disable Action |
| `auto_provision_mcp` | Auto-Provision Tools |
| `execute_zapier_read_action` | Execute Read Action |
| `execute_zapier_write_action` | Execute Write Action |
| `get_configuration_url` | Get Configuration URL |
| `list_zapier_skills` | List Saved Skills |
| `get_zapier_skill` | Get Saved Skill |
| `create_zapier_skill` | Create Saved Skill |
| `update_zapier_skill` | Update Saved Skill |
| `delete_zapier_skill` | Delete Saved Skill |
| `send_feedback` | Send Feedback |

Pattern is taken from [`figma/mcp-server-guide/.mcp.json`](https://github.com/figma/mcp-server-guide/blob/main/.mcp.json), which uses the same `_meta.ideTool*` namespace.

### Known consumers

- **Xcode** — the `ideToolIconRendersAsTemplate` field name lines up with macOS NSImage template-image semantics. Xcode 27's Coding Tools / MCP integration reads these.
- **Third-party MCP UIs** — e.g. [`wuhaoworld/cloud-claude/lib/plugins.ts`](https://github.com/wuhaoworld/cloud-claude/blob/main/lib/plugins.ts) reads `_meta.ideToolTitles` when rendering plugin tool lists.
- **Other clients** ignore the field per the MCP spec (`_meta` is reserved for implementation hints, unknown keys are silently dropped).

Classic-mode `app_action_name` tools are dynamic per user and cannot be pre-titled.

## Scope

- Only `plugins/zapier/.mcp.json` is edited.
- `zapier-power/mcp.json` (Kiro) and `gemini-extension.json` (Gemini) are intentionally untouched — figma's repo also keeps `_meta` only on the plugin-referenced `.mcp.json`.
- No README / AGENTS / llms.txt changes — the field is invisible to most readers.

## Test plan

All steps assume you've checked out the branch:

```bash
git fetch origin feat/add-ide-tool-titles
git checkout feat/add-ide-tool-titles
```

### 1. JSON validates

```bash
python3 -m json.tool plugins/zapier/.mcp.json > /dev/null && echo "valid"
```

### 2. All 14 tool titles are present

```bash
jq '.mcpServers.zapier._meta.ideToolTitles | length' plugins/zapier/.mcp.json
# → 14
```

```bash
jq -r '.mcpServers.zapier._meta.ideToolTitles | to_entries[] | "\(.key) → \(.value)"' plugins/zapier/.mcp.json
```

### 3. Icon path resolves

```bash
ls -la plugins/zapier/$(jq -r '.mcpServers.zapier._meta.ideToolIconPath' plugins/zapier/.mcp.json | sed 's|^\./||')
# → should list plugins/zapier/assets/icon.svg, non-zero size
```

### 4. Plugin still installs cleanly in Claude Code from this branch

Add the local checkout (on this branch) as a marketplace so Claude Code reads the modified file directly:

```
/plugin marketplace add /absolute/path/to/zapier-mcp     # this branch checked out
/plugin install zapier@zapier-plugins
```

Then restart Claude Code and:

```
/mcp                                                      # zapier should appear, no parse errors
```

Confirm there are no errors loading the plugin or registering the MCP server — that's what we're validating here. The `_meta` titles themselves are not currently surfaced by Claude Code's `/mcp` view, so visual confirmation is not expected from this client.

### 5. (Optional) Visual confirmation in a consuming client

In Xcode 27 or another `_meta.ideToolTitles`-aware client, installing this branch's `.mcp.json` should display the human-readable titles in the tool picker. If you have access to a consuming client, drop a screenshot in the comments.

## Rollback

If a consumer rejects unknown `_meta` keys (it shouldn't — MCP spec requires graceful ignore), revert the single file edit. No other surface changes to undo.
