### PR TITLE
chore: point human-facing links at docs.zapier.com instead of marketing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ Once the plugin is loaded, the rest of your guidance comes from the plugin itsel
 
 If the user has zero actions configured, trigger the [zapier-setup skill](./plugins/zapier/skills/zapier-setup/SKILL.md) ("setup zapier") to walk them through enabling actions.
 
+## Fetching Zapier docs
+
+Any `https://docs.zapier.com/<path>` page has a raw-markdown mirror — append `.md` to the URL to get it (e.g. `https://docs.zapier.com/mcp/home.md`). Prefer the `.md` form when fetching docs programmatically: it's smaller, renders cleanly in chat, and skips the marketing chrome.
+
 ## Where to find what
 
 | Need | File |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Zapier MCP
 
-Thanks for considering a contribution. This repo distributes plugin manifests, skills, and rules for [Zapier MCP](https://zapier.com/mcp) — the server itself is closed source.
+Thanks for considering a contribution. This repo distributes plugin manifests, skills, and rules for [Zapier MCP](https://docs.zapier.com/mcp/home) — the server itself is closed source.
 
 **In scope:** fixes to plugin manifests, skills, rules, brand assets, and docs in this repo.
 **Out of scope:** server behavior, app catalog, billing, or auth — file those with [Zapier Support](https://help.zapier.com).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # zapier-mcp
 
-> Official plugin distribution for [Zapier MCP](https://zapier.com/mcp). Install the plugin in your AI client and your agent gains access to 9,000+ apps and 40,000+ actions via Zapier's hosted Model Context Protocol server.
+> Official plugin distribution for [Zapier MCP](https://docs.zapier.com/mcp/home). Install the plugin in your AI client and your agent gains access to 9,000+ apps and 40,000+ actions via Zapier's hosted Model Context Protocol server.
 
 The hosted server lives at `mcp.zapier.com/api/v1/connect` and is closed source. This repo is the discovery and installation surface: plugin manifests, onboarding skills, and lifecycle rules that help your AI client use the server correctly from the first call.
 
 ## About Zapier MCP
 
-[Zapier MCP](https://zapier.com/mcp) is a hosted Model Context Protocol server that connects AI assistants to 9,000+ apps. Servers run in one of two modes:
+[Zapier MCP](https://docs.zapier.com/mcp/home) is a hosted Model Context Protocol server that connects AI assistants to 9,000+ apps. Servers run in one of two modes:
 
 - **Agentic** — Action discovery and execution are managed in chat through built-in meta-tools.
 - **Classic** — Each enabled action is exposed as a dedicated tool named `app_action_name`.
 
-The plugin in this repo detects which mode you're on and routes accordingly. For the full mode-specific built-in tool reference and product overview, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
+The plugin in this repo detects which mode you're on and routes accordingly. For the full mode-specific built-in tool reference and product overview, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home).
 
 https://github.com/user-attachments/assets/8304058f-67da-40b9-bc4f-5095b2817d61
 
@@ -28,7 +28,7 @@ What's **not** here:
 
 - The MCP server itself — hosted at `mcp.zapier.com` (closed source)
 - The action catalog — managed at [mcp.zapier.com](https://mcp.zapier.com)
-- Product documentation — at [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md)
+- Product documentation — at [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home)
 
 For a routing guide to specific skills, rules, and manifests, see [AGENTS.md](./AGENTS.md).
 
@@ -99,7 +99,7 @@ This repo is the source of truth for the plugin. It's also vendored or mirrored 
 ## Documentation & support
 
 - **Product overview**: [zapier.com/mcp](https://zapier.com/mcp)
-- **Documentation**: [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md)
+- **Documentation**: [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home)
 - **Support**: [help.zapier.com](https://help.zapier.com)
 - **For AI agents working in this repo**: [AGENTS.md](./AGENTS.md)
 - **For contributors**: [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/plugins/zapier/README.md
+++ b/plugins/zapier/README.md
@@ -1,6 +1,6 @@
 # Zapier Plugin
 
-Connects your AI client to [Zapier MCP](https://zapier.com/mcp) — Zapier's hosted Model Context Protocol server. Configure your actions at [mcp.zapier.com](https://mcp.zapier.com), and each one becomes a tool your AI can call directly.
+Connects your AI client to [Zapier MCP](https://docs.zapier.com/mcp/home) — Zapier's hosted Model Context Protocol server. Configure your actions at [mcp.zapier.com](https://mcp.zapier.com), and each one becomes a tool your AI can call directly.
 
 ## Quick Start
 
@@ -31,12 +31,12 @@ Zapier MCP servers run in one of two modes; the plugin detects which automatical
 - **Agentic** — Action discovery and execution are managed in chat through built-in meta-tools (`list_enabled_zapier_actions`, `discover_zapier_actions`, `execute_zapier_read_action`, etc.).
 - **Classic** — Each enabled action is exposed as a dedicated tool named `app_action_name` (e.g., `gmail_send_email`, `slack_find_message`).
 
-For the full mode-specific tool reference, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home.md).
+For the full mode-specific tool reference, see [docs.zapier.com/mcp/home](https://docs.zapier.com/mcp/home).
 
 ## Links
 
 - [Zapier MCP Dashboard](https://mcp.zapier.com) — Manage your server, authenticate apps, view connected tools
-- [Zapier MCP documentation](https://docs.zapier.com/mcp/home.md) — Full product docs
+- [Zapier MCP documentation](https://docs.zapier.com/mcp/home) — Full product docs
 - [Zapier status](https://status.zapier.com) — Check for outages
 
 ## Support

--- a/zapier-power/POWER.md
+++ b/zapier-power/POWER.md
@@ -118,7 +118,7 @@ Each enabled action becomes its own MCP tool named `app_action_name` (e.g., `sla
 
 ## License and support
 
-This power integrates with [Zapier MCP](https://zapier.com/mcp). The plugin distribution is MIT-licensed.
+This power integrates with [Zapier MCP](https://docs.zapier.com/mcp/home). The plugin distribution is MIT-licensed.
 
 - [Privacy Policy](https://zapier.com/privacy)
 - [Support](https://zapier.com/support)


### PR DESCRIPTION
Swaps five `zapier.com/mcp` (marketing) links on human-facing surfaces to `docs.zapier.com/mcp/home` (docs landing page). Also strips the `.md` mirror suffix from five existing links on those same surfaces — the bare URL renders as HTML.

Leaves the explicit "Product overview" entry, `server.json` `websiteUrl`, and the LLM-targeted `llms.txt` entries as-is.

`AGENTS.md` gains a one-paragraph note that any `docs.zapier.com` page has a raw-markdown mirror (append `.md`) for programmatic fetches.
