### PR TITLE
chore: rename README title to Zapier MCP Server Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zapier-mcp
+# Zapier MCP Server Plugin
 
 > Official plugin distribution for [Zapier MCP](https://zapier.com/mcp). Install the plugin in your AI client and your agent gains access to 9,000+ apps and 40,000+ actions via Zapier's hosted Model Context Protocol server.
 


### PR DESCRIPTION
Renames the H1 in `README.md` from `zapier-mcp` (repo slug) to `Zapier MCP Server Plugin` so the rendered page leads with the product/concept rather than the directory name.