### PR TITLE
Add Codex plugin manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Any `https://docs.zapier.com/<path>` page has a raw-markdown mirror — append `
 | Role-tailored toolkit setup | [plugins/zapier/skills/zapier-explore/SKILL.md](./plugins/zapier/skills/zapier-explore/SKILL.md) |
 | Status / health checks | [plugins/zapier/skills/zapier-status/SKILL.md](./plugins/zapier/skills/zapier-status/SKILL.md) |
 | Claude Code plugin manifest | [plugins/zapier/.claude-plugin/plugin.json](./plugins/zapier/.claude-plugin/plugin.json) |
+| OpenAI Codex plugin manifest | [plugins/zapier/.codex-plugin/plugin.json](./plugins/zapier/.codex-plugin/plugin.json) |
 | Cursor plugin manifest | [plugins/zapier/.cursor-plugin/plugin.json](./plugins/zapier/.cursor-plugin/plugin.json) |
 | GitHub Copilot CLI plugin manifest | [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json) |
 | Kiro Power manifest + steering | [zapier-power/](./zapier-power/) |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We ship this plugin to the following marketplaces:
 
 - [AGENTS.md](./AGENTS.md): guide for AI agents working in this repo
 - [CONTRIBUTING.md](./CONTRIBUTING.md): how to contribute
-- **Per-client manifests**: [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json)
+- **Per-client manifests**: [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [OpenAI Codex](./plugins/zapier/.codex-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json)
 - [`llms.txt`](./llms.txt): LLM discovery index
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,7 @@ This repository contains per-client plugin manifests, install assets, skills, an
 Per-client install manifests live under `plugins/zapier/`. Each surfaces the same MCP server (`mcp.zapier.com/api/v1/connect`) shaped for a specific client.
 
 - [Claude Code plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.claude-plugin/plugin.json): Manifest for Claude Code's plugin marketplace.
+- [OpenAI Codex plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.codex-plugin/plugin.json): Manifest for OpenAI Codex's plugin marketplace.
 - [Cursor plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.cursor-plugin/plugin.json): Manifest for Cursor's plugin marketplace.
 - [MCP server config](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.mcp.json): Generic `mcpServers` declaration with `"type": "http"`.
 - [Claude marketplace registry](https://github.com/zapier/zapier-mcp/blob/main/.claude-plugin/marketplace.json): Top-level marketplace entry pointing at `plugins/zapier`.

--- a/plugins/zapier/.codex-plugin/plugin.json
+++ b/plugins/zapier/.codex-plugin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "zapier",
+  "version": "1.0.0",
+  "description": "Connect 9,000+ apps to your AI workflow. Discover, enable, and execute Zapier actions directly from your client.",
+  "author": {
+    "name": "Zapier",
+    "email": "support@zapier.com",
+    "url": "https://zapier.com"
+  },
+  "homepage": "https://docs.zapier.com/mcp/home",
+  "repository": "https://github.com/zapier/zapier-mcp",
+  "license": "MIT",
+  "keywords": [
+    "zapier",
+    "mcp",
+    "model-context-protocol",
+    "automation",
+    "integrations",
+    "workflow",
+    "ai-actions",
+    "api",
+    "no-code",
+    "ai-tools",
+    "productivity"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Zapier",
+    "shortDescription": "Connect your AI to 9,000+ apps via the hosted Zapier MCP server.",
+    "longDescription": "Zapier MCP is a hosted server that connects your AI to 9,000+ apps. Send messages, pull data, trigger workflows — all in plain English. This plugin bundles the MCP server connection with guided onboarding, a quick demo, and role-tailored skills so your assistant arrives already knowing how to use Zapier well.",
+    "developerName": "Zapier",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.zapier.com/mcp/home",
+    "privacyPolicyURL": "https://zapier.com/privacy",
+    "termsOfServiceURL": "https://zapier.com/tos",
+    "defaultPrompt": [
+      "Show me around the Zapier MCP plugin and get me set up",
+      "Find a Zapier action that sends a Slack message and try it",
+      "List the Zapier apps I have connected and what actions are available"
+    ],
+    "brandColor": "#FF4F00",
+    "logo": "./assets/logo.svg",
+    "composerIcon": "./assets/icon.svg"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `plugins/zapier/.codex-plugin/plugin.json` mirroring the Claude Code manifest with the fields OpenAI Codex additionally requires (interface block, defaultPrompt, brand color, logos).
- Reuses the existing `./skills/` and `./.mcp.json` — same MCP server, shaped for Codex.
- Update discovery surfaces so the new manifest is findable: README's per-client manifest list, the AGENTS.md file map, and `llms.txt`.

Follows the pattern from [zapier/sdk](https://github.com/zapier/sdk/blob/main/.codex-plugin/plugin.json) (`.codex-plugin/plugin.json`). Marketplace-side listing (adding this plugin to `zapier/marketplace`'s Codex registry) will follow in a separate PR.

## Notes

- The repo's Claude Code and Cursor top-level marketplace registries (`.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`) do not yet have a Codex sibling (`.agents/plugins/marketplace.json` per the format `zapier/marketplace` uses). Left out of this PR — worth a follow-up if we want this repo directly installable as a Codex marketplace too.

## Test plan

- [ ] Install via Codex: `codex plugin marketplace add zapier/marketplace && codex plugin add zapier@zapier-mcp` (once the marketplace registry is updated)
- [ ] Confirm `interface` metadata renders as expected in the Codex plugin picker
- [ ] Confirm MCP server connection loads via `./.mcp.json`