### PR TITLE
feat: add Gemini CLI extension manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,14 @@ copilot plugin marketplace add zapier/marketplace
 copilot plugin install mcp@zapier
 ```
 
+### Gemini CLI
+
+```
+gemini extensions install https://github.com/zapier/zapier-mcp
+```
+
+After install, the user authenticates inside Gemini with `/mcp auth zapier`.
+
 ### Kiro
 
 Direct the user to [kiro.dev/powers](https://kiro.dev/powers), find Zapier, and click **Add to Kiro**. Powers register through the IDE — no command-line setup.
@@ -86,6 +94,7 @@ Any `https://docs.zapier.com/<path>` page has a raw-markdown mirror — append `
 | OpenAI Codex plugin manifest | [plugins/zapier/.codex-plugin/plugin.json](./plugins/zapier/.codex-plugin/plugin.json) |
 | Cursor plugin manifest | [plugins/zapier/.cursor-plugin/plugin.json](./plugins/zapier/.cursor-plugin/plugin.json) |
 | GitHub Copilot CLI plugin manifest | [plugins/zapier/.github/plugin/plugin.json](./plugins/zapier/.github/plugin/plugin.json) |
+| Gemini CLI extension manifest | [gemini-extension.json](./gemini-extension.json) |
 | Kiro Power manifest + steering | [zapier-power/](./zapier-power/) |
 | MCP Registry manifest | [server.json](./server.json) |
 | LLM discovery index | [llms.txt](./llms.txt) |

--- a/README.md
+++ b/README.md
@@ -26,11 +26,19 @@ This repo doesn't host its own marketplace — install the plugin through one of
 
 All of these pull the plugin straight from [`plugins/zapier/`](./plugins/zapier/) in this repo, so they always stay in sync with it.
 
+Gemini CLI is the one exception — it installs directly from this repo's root, not through an external marketplace:
+
+```
+gemini extensions install https://github.com/zapier/zapier-mcp
+```
+
+Authenticate inside Gemini with `/mcp auth zapier`. The catalog entry is [`gemini-extension.json`](./gemini-extension.json) at the repo root, auto-indexed into the [Gemini CLI Extensions gallery](https://geminicli.com/extensions).
+
 ## For contributors
 
 - [AGENTS.md](./AGENTS.md): guide for AI agents working in this repo
 - [CONTRIBUTING.md](./CONTRIBUTING.md): how to contribute
-- **Per-client manifests**: [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [OpenAI Codex](./plugins/zapier/.codex-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), and [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json)
+- **Per-client manifests**: [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [OpenAI Codex](./plugins/zapier/.codex-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), and [Gemini CLI](./gemini-extension.json)
 - [`llms.txt`](./llms.txt): LLM discovery index
 
 ---

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,13 @@
+{
+  "name": "zapier",
+  "version": "1.0.0",
+  "description": "Official plugin distribution for the hosted Zapier MCP server. Connects Gemini CLI to thousands of apps — send messages, pull data, trigger workflows.",
+  "mcpServers": {
+    "zapier": {
+      "httpUrl": "https://mcp.zapier.com/api/v1/connect",
+      "oauth": {
+        "enabled": true
+      }
+    }
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ Per-client install manifests live under `plugins/zapier/`. Each surfaces the sam
 - [Claude Code plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.claude-plugin/plugin.json): Manifest for Claude Code's plugin marketplace.
 - [OpenAI Codex plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.codex-plugin/plugin.json): Manifest for OpenAI Codex's plugin marketplace.
 - [Cursor plugin manifest](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.cursor-plugin/plugin.json): Manifest for Cursor's plugin marketplace.
+- [Gemini CLI extension manifest](https://github.com/zapier/zapier-mcp/blob/main/gemini-extension.json): `gemini-extension.json` for `gemini extensions install` from the GitHub URL, auto-indexed into the Gemini CLI Extensions gallery.
 - [MCP server config](https://github.com/zapier/zapier-mcp/blob/main/plugins/zapier/.mcp.json): Generic `mcpServers` declaration with `"type": "http"`.
 - [MCP Registry manifest](https://github.com/zapier/zapier-mcp/blob/main/server.json): `server.json` for the [official MCP Registry](https://registry.modelcontextprotocol.io) catalog.
 - [`zapier/marketplace`](https://github.com/zapier/marketplace): install this plugin (and every other Zapier plugin) through Zapier's marketplace for coding agents.


### PR DESCRIPTION
## Summary

Adds `gemini-extension.json` at the repo root so users can install Zapier MCP via Gemini CLI.

**Once merged**, the install command is:

```
gemini extensions install https://github.com/zapier/zapier-mcp
```

**To test this branch before merging**:

```
gemini extensions install --consent https://github.com/zapier/zapier-mcp --ref feat/add-gemini-extension
```

Format follows [Gemini's extension reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/reference.md) — `httpUrl` for the MCP endpoint (Gemini's convention for HTTP servers) and `oauth.enabled: true` to trigger the OAuth flow against `mcp.zapier.com`.

Recreated from an earlier draft (#34, closed unmerged) that landed on the same manifest shape independently. Description reworded to avoid a hardcoded app count, matching our current convention elsewhere in this repo.

Also adds the Gemini CLI install path to `README.md`, `AGENTS.md`, and `llms.txt`.

## Status: draft — not yet end-to-end tested

Schema shape matches Gemini's documented reference, but the OAuth round-trip against `mcp.zapier.com/api/v1/connect` from a live Gemini session hasn't been run. That's the actual blocker for merging, same as it was on #34.

## Test plan

Prereq: `brew install gemini-cli`

**1. Schema validation**

```bash
gemini extensions validate /path/to/this/checkout
```

**2. Local install from checkout**

```bash
gemini extensions uninstall zapier 2>/dev/null
gemini extensions link --consent /path/to/this/checkout
gemini extensions list   # → should show "zapier" with MCP server "zapier"
```

**3. Install from this branch on GitHub**

```bash
gemini extensions uninstall zapier
gemini extensions install --consent https://github.com/zapier/zapier-mcp --ref feat/add-gemini-extension
gemini extensions list
```

**4. OAuth + tool exposure inside Gemini (the actual blocker for merging)**

```
/extensions list           # confirms "zapier" present and enabled
/mcp auth zapier            # opens mcp.zapier.com OAuth — sign in
/mcp                        # confirm "zapier" appears with tools listed
```

**5. Smoke a tool**

With at least one action enabled at mcp.zapier.com, ask Gemini to do something concrete (e.g. "List my enabled Zapier actions"). Confirm Gemini calls the tool and the response is non-empty.

## Notes

- `httpUrl` (not `url` + `type: http`) is intentional — Gemini's documented field name for HTTP MCP servers in extension manifests.
- Purely additive — no existing client paths are touched.