### PR TITLE
Add one-click install deep links, trim README cruft

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,16 @@ This plugin is the part that lives in your AI client. Install it from your clien
 
 This repo doesn't host its own marketplace — install the plugin through one of these:
 
-- [`zapier/marketplace`](https://github.com/zapier/marketplace): Zapier's marketplace for coding agents, covering this plugin plus every other Zapier plugin (Notion, Google Sheets, the SDK, and more)
-- [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official): Anthropic's curated Claude Code marketplace
-- [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins): Anthropic's Claude Cowork marketplace
-- [`kirodotdev/powers`](https://github.com/kirodotdev/powers): Kiro's Powers catalog, browsable at [kiro.dev/powers](https://kiro.dev/powers)
-- [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier): Cursor's MCP server registry, surfaced at [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier)
+- **Claude Code**: [![Install in Claude Code](https://img.shields.io/badge/Claude_Code-Install_Server-D97757?style=flat-square&logo=claude&logoColor=white)](claude://code/new?q=Install%20Zapier%20MCP%20for%20me%20globally.%0A%0ARun%20this%20command%3A%0A%20%20claude%20mcp%20add%20--transport%20http%20%22Zapier-MCP%22%20https%3A//mcp.zapier.com/api/v1/connect%0A%0AThen%20give%20me%20step-by-step%20instructions%20for%20how%20to%20restart%20Claude%20Code.%20After%20restarting%2C%20use%20get_zapier_skill%20with%20name%20%22zapier%3Aonboarding%22%20and%20follow%20its%20instructions%20to%20set%20me%20up.) — or add [`zapier/marketplace`](https://github.com/zapier/marketplace) / [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) manually
+- **Cursor**: [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier), via [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier)
+- **VS Code**: [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22zapier%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%2C%22type%22%3A%22http%22%2C%22icons%22%3A%7B%22src%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Ficon-mcp.png%22%7D%7D)
+- **OpenAI Codex**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
+- **GitHub Copilot CLI**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
+- **Claude Cowork**: via [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins)
+- **Kiro**: [kiro.dev/powers](https://kiro.dev/powers)
+- **Gemini CLI**: `gemini extensions install https://github.com/zapier/zapier-mcp`, then `/mcp auth zapier` — see [`gemini-extension.json`](./gemini-extension.json)
 
-All of these pull the plugin straight from [`plugins/zapier/`](./plugins/zapier/) in this repo, so they always stay in sync with it.
-
-Gemini CLI is the one exception — it installs directly from this repo's root, not through an external marketplace:
-
-```
-gemini extensions install https://github.com/zapier/zapier-mcp
-```
-
-Authenticate inside Gemini with `/mcp auth zapier`. The catalog entry is [`gemini-extension.json`](./gemini-extension.json) at the repo root, auto-indexed into the [Gemini CLI Extensions gallery](https://geminicli.com/extensions).
+All of these pull the plugin straight from [`plugins/zapier/`](./plugins/zapier/) in this repo, except VS Code, which connects directly to the hosted MCP server.
 
 ## Third-party registries
 
@@ -49,9 +44,4 @@ Zapier MCP is also listed on:
 
 - [AGENTS.md](./AGENTS.md): guide for AI agents working in this repo
 - [CONTRIBUTING.md](./CONTRIBUTING.md): how to contribute
-- **Per-client manifests**: [Claude Code](./plugins/zapier/.claude-plugin/plugin.json), [OpenAI Codex](./plugins/zapier/.codex-plugin/plugin.json), [Cursor](./plugins/zapier/.cursor-plugin/plugin.json), [GitHub Copilot CLI](./plugins/zapier/.github/plugin/plugin.json), and [Gemini CLI](./gemini-extension.json)
 - [`llms.txt`](./llms.txt): LLM discovery index
-
----
-
-*Zapier MCP is part of the [Model Context Protocol](https://modelcontextprotocol.io/) ecosystem.*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![MCP Registry](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fcom.zapier%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/v0.1/servers/com.zapier%2Fmcp/versions/latest)
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools 'MCP Server')](https://modelcontextprotocol.io/)
 [![License](https://img.shields.io/github/license/zapier/zapier-mcp)](./LICENSE)
+[![Install in Claude Code](https://img.shields.io/badge/Claude_Code-Install_Server-D97757?style=flat-square&logo=claude&logoColor=white)](claude://code/new?q=Install%20Zapier%20MCP%20for%20me%20globally.%0A%0ARun%20this%20command%3A%0A%20%20claude%20mcp%20add%20--transport%20http%20%22Zapier-MCP%22%20https%3A//mcp.zapier.com/api/v1/connect%0A%0AThen%20give%20me%20step-by-step%20instructions%20for%20how%20to%20restart%20Claude%20Code.%20After%20restarting%2C%20use%20get_zapier_skill%20with%20name%20%22zapier%3Aonboarding%22%20and%20follow%20its%20instructions%20to%20set%20me%20up.)
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22zapier%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%2C%22type%22%3A%22http%22%2C%22icons%22%3A%7B%22src%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Ficon-mcp.png%22%7D%7D)
 
 # Zapier MCP Plugin Distribution
 
@@ -22,9 +24,9 @@ This plugin is the part that lives in your AI client. Install it from your clien
 
 ## Where to install this plugin
 
-- **Claude Code**: [![Install in Claude Code](https://img.shields.io/badge/Claude_Code-Install_Server-D97757?style=flat-square&logo=claude&logoColor=white)](claude://code/new?q=Install%20Zapier%20MCP%20for%20me%20globally.%0A%0ARun%20this%20command%3A%0A%20%20claude%20mcp%20add%20--transport%20http%20%22Zapier-MCP%22%20https%3A//mcp.zapier.com/api/v1/connect%0A%0AThen%20give%20me%20step-by-step%20instructions%20for%20how%20to%20restart%20Claude%20Code.%20After%20restarting%2C%20use%20get_zapier_skill%20with%20name%20%22zapier%3Aonboarding%22%20and%20follow%20its%20instructions%20to%20set%20me%20up.) — or add [`zapier/marketplace`](https://github.com/zapier/marketplace) / [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) manually
+- **Claude Code**: add [`zapier/marketplace`](https://github.com/zapier/marketplace) or [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) manually
 - **Cursor**: [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier), via [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier)
-- **VS Code**: [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22zapier%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%2C%22type%22%3A%22http%22%2C%22icons%22%3A%7B%22src%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Ficon-mcp.png%22%7D%7D)
+- **VS Code**: connects directly to the hosted MCP server — use the badge above, or add `https://mcp.zapier.com/api/v1/connect` (`type: http`) manually
 - **OpenAI Codex**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
 - **GitHub Copilot CLI**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
 - **Claude Cowork**: via [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ![Zapier MCP](./assets/mcp-logo.png)
 
 [![MCP Registry](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fcom.zapier%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/v0.1/servers/com.zapier%2Fmcp/versions/latest)
+[![MCP Server](https://badge.mcpx.dev?type=server&features=tools 'MCP Server')](https://modelcontextprotocol.io/)
+[![License](https://img.shields.io/github/license/zapier/zapier-mcp)](./LICENSE)
 
 # Zapier MCP Plugin Distribution
 
 The official home of the [Zapier MCP](https://docs.zapier.com/mcp/home) plugin — the safest way to give an agent access to your apps. ⚡
 
-Zapier MCP is a hosted server that gives your AI governed, credential-safe access to 9,000+ apps — OAuth-managed, nothing exposed to the model. Send messages, pull data, trigger workflows. All in plain English.
+Zapier MCP is a hosted server that gives your AI governed, credential-safe access to 9,000+ apps. Send messages, pull data, trigger workflows. All in plain English.
 
 This plugin is the part that lives in your AI client. Install it from your client's marketplace and your assistant arrives knowing how to use Zapier well, with guided onboarding, a quick demo, and skills tailored to your role.
 
@@ -20,8 +22,6 @@ This plugin is the part that lives in your AI client. Install it from your clien
 
 ## Where to install this plugin
 
-This repo doesn't host its own marketplace — install the plugin through one of these:
-
 - **Claude Code**: [![Install in Claude Code](https://img.shields.io/badge/Claude_Code-Install_Server-D97757?style=flat-square&logo=claude&logoColor=white)](claude://code/new?q=Install%20Zapier%20MCP%20for%20me%20globally.%0A%0ARun%20this%20command%3A%0A%20%20claude%20mcp%20add%20--transport%20http%20%22Zapier-MCP%22%20https%3A//mcp.zapier.com/api/v1/connect%0A%0AThen%20give%20me%20step-by-step%20instructions%20for%20how%20to%20restart%20Claude%20Code.%20After%20restarting%2C%20use%20get_zapier_skill%20with%20name%20%22zapier%3Aonboarding%22%20and%20follow%20its%20instructions%20to%20set%20me%20up.) — or add [`zapier/marketplace`](https://github.com/zapier/marketplace) / [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) manually
 - **Cursor**: [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier), via [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier)
 - **VS Code**: [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22zapier%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%2C%22type%22%3A%22http%22%2C%22icons%22%3A%7B%22src%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Ficon-mcp.png%22%7D%7D)
@@ -30,8 +30,6 @@ This repo doesn't host its own marketplace — install the plugin through one of
 - **Claude Cowork**: via [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins)
 - **Kiro**: [kiro.dev/powers](https://kiro.dev/powers)
 - **Gemini CLI**: `gemini extensions install https://github.com/zapier/zapier-mcp`, then `/mcp auth zapier` — see [`gemini-extension.json`](./gemini-extension.json)
-
-All of these pull the plugin straight from [`plugins/zapier/`](./plugins/zapier/) in this repo, except VS Code, which connects directly to the hosted MCP server.
 
 ## Third-party registries
 


### PR DESCRIPTION
## Summary
- Added one-click install links for Claude Code and VS Code (deep-links directly into the client)
- Listed every plugin-install client explicitly, including OpenAI Codex and GitHub Copilot CLI, which weren't called out before
- Collapsed the Gemini CLI section down to a single line
- Removed the per-client manifest links and the closing "part of the MCP ecosystem" line — low value, taking up space

## Test plan
- [ ] Click the Claude Code and VS Code badges from a machine with each client installed, confirm they open with the install prompt/config pre-filled
- [ ] Confirm all listed links resolve