### PR TITLE
Fix broken Claude Code/VS Code badges, restructure install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![MCP Registry](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fcom.zapier%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/v0.1/servers/com.zapier%2Fmcp/versions/latest)
 [![MCP Server](https://badge.mcpx.dev?type=server&features=tools 'MCP Server')](https://modelcontextprotocol.io/)
 [![License](https://img.shields.io/github/license/zapier/zapier-mcp)](./LICENSE)
-[![Install in Claude Code](https://img.shields.io/badge/Claude_Code-Install_Server-D97757?style=flat-square&logo=claude&logoColor=white)](claude://code/new?q=Install%20Zapier%20MCP%20for%20me%20globally.%0A%0ARun%20this%20command%3A%0A%20%20claude%20mcp%20add%20--transport%20http%20%22Zapier-MCP%22%20https%3A//mcp.zapier.com/api/v1/connect%0A%0AThen%20give%20me%20step-by-step%20instructions%20for%20how%20to%20restart%20Claude%20Code.%20After%20restarting%2C%20use%20get_zapier_skill%20with%20name%20%22zapier%3Aonboarding%22%20and%20follow%20its%20instructions%20to%20set%20me%20up.)
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](vscode:mcp/install?%7B%22name%22%3A%22zapier%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%2C%22type%22%3A%22http%22%2C%22icons%22%3A%7B%22src%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Ficon-mcp.png%22%7D%7D)
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=zapier&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.zapier.com%2Fapi%2Fv1%2Fconnect%22%7D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=zapier&config=eyJ1cmwiOiAiaHR0cHM6Ly9tY3AuemFwaWVyLmNvbS9hcGkvdjEvY29ubmVjdCJ9)
 
 # Zapier MCP Plugin Distribution
 
@@ -14,24 +14,26 @@ Zapier MCP is a hosted server that gives your AI governed, credential-safe acces
 
 This plugin is the part that lives in your AI client. Install it from your client's marketplace and your assistant arrives knowing how to use Zapier well, with guided onboarding, a quick demo, and skills tailored to your role.
 
-**Get started with the plugin** → [docs.zapier.com/mcp/clients](https://docs.zapier.com/mcp/clients)
-
 ![AI connects to Zapier MCP, which connects to Gmail, Slack, Google Sheets, Notion, HubSpot, Salesforce, Linear, Asana, and 9,000 more apps](./assets/mcp-apps-diagram.png)
 
 ## What's in this repo
 
 - **[`plugins/zapier/`](./plugins/zapier/)**: the plugin that onboards you to Zapier MCP and supercharges your experience
 
-## Where to install this plugin
+## Getting started
 
-- **Claude Code**: add [`zapier/marketplace`](https://github.com/zapier/marketplace) or [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) manually
-- **Cursor**: [cursor.com/marketplace/zapier](https://cursor.com/marketplace/zapier), via [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier)
-- **VS Code**: connects directly to the hosted MCP server — use the badge above, or add `https://mcp.zapier.com/api/v1/connect` (`type: http`) manually
-- **OpenAI Codex**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
-- **GitHub Copilot CLI**: via [`zapier/marketplace`](https://github.com/zapier/marketplace)
-- **Claude Cowork**: via [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins)
-- **Kiro**: [kiro.dev/powers](https://kiro.dev/powers)
+Connecting Zapier MCP to your AI client only takes a server URL — see [docs.zapier.com/mcp/clients](https://docs.zapier.com/mcp/clients) for step-by-step instructions for every supported client.
+
+A few clients also install the plugin distributed from this repo, which layers guided onboarding, a first-use demo, and role-tailored skills on top of that base connection:
+
+- **Claude Code**: add [`zapier/marketplace`](https://github.com/zapier/marketplace) or [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official)
+- **Cursor**: use the badge above, or add [`cursor/mcp-servers`](https://github.com/cursor/mcp-servers/tree/main/servers/zapier)
+- **OpenAI Codex** and **GitHub Copilot CLI**: add [`zapier/marketplace`](https://github.com/zapier/marketplace)
+- **Claude Cowork**: add [`anthropics/knowledge-work-plugins`](https://github.com/anthropics/knowledge-work-plugins)
+- **Kiro**: via [kiro.dev/powers](https://kiro.dev/powers)
 - **Gemini CLI**: `gemini extensions install https://github.com/zapier/zapier-mcp`, then `/mcp auth zapier` — see [`gemini-extension.json`](./gemini-extension.json)
+
+VS Code connects directly to the hosted MCP server rather than through a plugin — use the badge above, or add `https://mcp.zapier.com/api/v1/connect` (`type: http`) manually.
 
 ## Third-party registries
 
@@ -44,4 +46,4 @@ Zapier MCP is also listed on:
 
 - [AGENTS.md](./AGENTS.md): guide for AI agents working in this repo
 - [CONTRIBUTING.md](./CONTRIBUTING.md): how to contribute
-- [`llms.txt`](./llms.txt): LLM discovery index
+- [llms.txt](./llms.txt): LLM discovery index

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@
 
 # Zapier MCP Plugin Distribution
 
-The official home of the [Zapier MCP](https://docs.zapier.com/mcp/home) plugin — the safest way to give an agent access to your apps. ⚡
+[Zapier MCP](https://docs.zapier.com/mcp/home) gives any MCP-compatible AI client governed access to 9,000+ apps — send messages, pull data, trigger workflows, all in plain English. No code, no infrastructure, SOC 2 Type II certified. ⚡
 
-Zapier MCP is a hosted server that gives your AI governed, credential-safe access to 9,000+ apps. Send messages, pull data, trigger workflows. All in plain English.
-
-This plugin is the part that lives in your AI client. Install it from your client's marketplace and your assistant arrives knowing how to use Zapier well, with guided onboarding, a quick demo, and skills tailored to your role.
+This repo distributes the Zapier MCP plugin — the part that lives in your AI client. Install it from your client's marketplace and your assistant arrives knowing how to use Zapier well, with guided onboarding, a quick demo, and skills tailored to your role.
 
 ![AI connects to Zapier MCP, which connects to Gmail, Slack, Google Sheets, Notion, HubSpot, Salesforce, Linear, Asana, and 9,000 more apps](./assets/mcp-apps-diagram.png)
 


### PR DESCRIPTION
## Summary
- The Claude Code and VS Code badges from the previous PR didn't actually work — GitHub strips custom URI schemes (`claude://`, `vscode:`) from link hrefs and silently falls back to linking the badge image itself, so clicking just opened an image instead of the app
- Fixed VS Code and added a Cursor badge using their official HTTPS redirector pages, which survive GitHub's link sanitizer
- Removed the Claude Code badge entirely — no such redirector exists for it, and Anthropic's own docs say the fallback is a code block, not a button, which we decided wasn't worth the clutter
- Replaced the "Where to install this plugin" bullet list with a "Getting started" section pointing to docs.zapier.com/mcp/clients for base connection steps, since that page covers every client and stays current on its own

## Test plan
- [ ] Click the VS Code and Cursor badges and confirm they land on the real install flow (not just an image)
- [ ] Confirm all other links resolve